### PR TITLE
Call ofw_coupons_enabled filter after wp_loaded hook, OFW-153

### DIFF
--- a/offers-for-woocommerce.php
+++ b/offers-for-woocommerce.php
@@ -94,7 +94,7 @@ register_deactivation_hook( __FILE__ , array('Angelleye_Offers_For_Woocommerce',
  *
  * @since	0.1.0
  */
-add_action( 'wp_loaded', array( 'Angelleye_Offers_For_Woocommerce', 'get_instance' ) );
+add_action( 'plugins_loaded', array( 'Angelleye_Offers_For_Woocommerce', 'get_instance' ) );
 
 /**
  **********************************************

--- a/offers-for-woocommerce.php
+++ b/offers-for-woocommerce.php
@@ -94,7 +94,7 @@ register_deactivation_hook( __FILE__ , array('Angelleye_Offers_For_Woocommerce',
  *
  * @since	0.1.0
  */
-add_action( 'plugins_loaded', array( 'Angelleye_Offers_For_Woocommerce', 'get_instance' ) );
+add_action( 'wp_loaded', array( 'Angelleye_Offers_For_Woocommerce', 'get_instance' ) );
 
 /**
  **********************************************


### PR DESCRIPTION
When we call WC()->cart function within ofw_coupons_filter before the wp_loaded function it breaks the cart feature, This issue was reported by a customer using Zapier plugin with Offer for Woocommerce plugin, So it resolves a compatibility issue with Zapier + Woo Coupon + OFW