### PR TITLE
Normalize Sale-Product Offer Behavior

### DIFF
--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -747,11 +747,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         if (!is_object($_product)) {
             return;
         }
-        if (version_compare(WC_VERSION, '3.0', '<')) {
-            $class_hidden = ( isset($_product->product_type) && $_product->product_type == 'external' ) ? ' custom_tab_offers_for_woocommerce_hidden' : '';
-        } else {
-            $class_hidden = ( $_product->get_type() == 'external' ) ? ' custom_tab_offers_for_woocommerce_hidden' : '';
-        }
+        $class_hidden = ( ofwc_get_product_type($_product) == 'external' ) ? ' custom_tab_offers_for_woocommerce_hidden' : '';
 
         print(
                 '<li id="custom_tab_offers_for_woocommerce" class="custom_tab_offers_for_woocommerce ' . $class_hidden . '"><a href="#custom_tab_data_offers_for_woocommerce"><span>' . __('Offers', 'offers-for-woocommerce') . '</span></a></li>'
@@ -1627,11 +1623,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
 
                         $_product_managing_stock = ( $_product_variant->managing_stock() ) ? $_product_variant->managing_stock() : $_product->managing_stock();
 
-                        if (version_compare(WC_VERSION, '3.0', '<')) {
-                            $_product_stock = ( $_product_variant_managing_stock ) ? $_product_variant->get_total_stock() : $_product->get_total_stock();
-                        } else {
-                            $_product_stock = ( $_product_variant_managing_stock ) ? $_product_variant->get_stock_quantity() : $_product->get_stock_quantity();
-                        }
+                        $_product_stock = ( $_product_variant_managing_stock ) ? ofwc_get_product_stock_quantity($_product_variant) : ofwc_get_product_stock_quantity($_product);
 
                         $_product_in_stock = ( $_product_variant_managing_stock ) ? $_product_variant->has_enough_stock($postmeta['offer_quantity'][0]) : $_product->has_enough_stock($postmeta['offer_quantity'][0]);
                         $_product_backorders_allowed = ( $_product_variant_managing_stock ) ? $_product_variant->backorders_allowed() : $_product->backorders_allowed();
@@ -1645,7 +1637,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
                         $_product_regular_price = $_product->get_regular_price();
                         $_product_sale_price = $_product->get_sale_price();
                         $_product_managing_stock = $_product->managing_stock();
-                        $_product_stock = version_compare(WC_VERSION, '3.0', '<') ? $_product->get_total_stock() : $_product->get_stock_quantity();
+                        $_product_stock = ofwc_get_product_stock_quantity($_product);
                         $_product_in_stock = $_product->has_enough_stock($postmeta['offer_quantity'][0]);
                         $_product_backorders_allowed = $_product->backorders_allowed();
                         $_product_backorders_require_notification = $_product->backorders_require_notification();
@@ -1656,7 +1648,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
                     }
 
                     /* Products Addon and Offers Plugin meta check starts */
-                    $product_addon_id = version_compare(WC_VERSION, '3.0', '<') ? $_product->post->ID : $_product->get_id();
+                    $product_addon_id = ofwc_get_product_id($_product);
                     $_product_addons_data = get_post_meta($product_addon_id, '_product_addons', true);
                     /* Products Addon and Offers Plugin meta check end. */
 
@@ -4096,7 +4088,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
      */
     public function woocommerce_product_quick_edit_save_own($product) {
 
-        $post_id = version_compare(WC_VERSION, '3.0', '<') ? $product->id : $product->get_id();
+        $post_id = ofwc_get_product_id($product);
 
         $offers_for_woocommerce_enabled = (isset($_REQUEST['offers_for_woocommerce_enabled']) && $_REQUEST['offers_for_woocommerce_enabled'] == 'yes') ? 'yes' : 'no';
         $offers_for_woocommerce_auto_accept_enabled = (isset($_REQUEST['_offers_for_woocommerce_auto_accept_enabled']) && $_REQUEST['_offers_for_woocommerce_auto_accept_enabled'] == 'yes' ) ? 'yes' : 'no';
@@ -4762,7 +4754,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         $order_items = $order->get_items();
         // Check for offer id
         foreach ($order_items as $key => $value) {
-            $item_offer_id = wc_get_order_item_meta( $key, 'Offer ID',true );
+            $item_offer_id = is_object($value) && method_exists($value, 'get_meta') ? $value->get_meta('Offer ID', true) : wc_get_order_item_meta($key, 'Offer ID', true);
             /**
              * Update offer
              * Add postmeta value 'offer_order_id' for this order id

--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -35,6 +35,26 @@ class Angelleye_Offers_For_Woocommerce_Admin {
     protected $plugin_screen_hook_suffix = null;
 
     /**
+     * Build an admin edit URL for a WooCommerce order that works with both legacy storage and HPOS.
+     *
+     * @param int $order_id Order ID.
+     * @return string
+     */
+    private function ofwc_get_order_edit_url($order_id) {
+        $order_id = absint($order_id);
+
+        if (
+            function_exists('wc_get_container')
+            && class_exists('\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController')
+            && wc_get_container()->get(\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class)->custom_orders_table_usage_is_enabled()
+        ) {
+            return admin_url('admin.php?page=wc-orders&action=edit&id=' . $order_id);
+        }
+
+        return admin_url('post.php?post=' . $order_id . '&action=edit');
+    }
+
+    /**
      * Initialize the plugin by loading admin scripts & styles and adding a settings page and menu
      * @since     0.1.0
      */
@@ -1667,19 +1687,17 @@ class Angelleye_Offers_For_Woocommerce_Admin {
 
                         // Set order meta data array
 
-                        $offer_order_meta['Order ID'] = '<a href="post.php?post=' . $order_id . '&action=edit">' . '#' . $order_id . '</a>';
+                        $offer_order_meta['Order ID'] = '<a href="' . esc_url($this->ofwc_get_order_edit_url($order_id)) . '">#' . $order_id . '</a>';
 
                         // Get Order
-                        $order = new WC_Order($order_id);
-                        if ($order->post) {
-                            $offer_order_meta['Order Date'] = $order->post->post_date;
+                        $order = wc_get_order($order_id);
+                        if ($order) {
+                            $order_date = $order->get_date_created();
+                            $offer_order_meta['Order Date'] = $order_date ? $order_date->date_i18n('Y-m-d H:i:s') : '';
                             $offer_order_meta['Order Status'] = ucwords($order->get_status());
                         } else {
                             $offer_order_meta['Order ID'] .= '<br /><small><strong>Notice: </strong>' . __('Order not found; may have been deleted', 'offers-for-woocommerce') . '</small>';
                         }
-
-                        $offer_order_meta['Order Date'] = $order->post->post_date;
-                        $offer_order_meta['Order Status'] = ucwords($order->get_status());
                     } else {
                         $offer_order_meta['Order ID'] = '<br /><small><strong>Notice: </strong>' . __('Order not found; may have been deleted', 'offers-for-woocommerce') . '</small>';
                     }
@@ -4736,7 +4754,10 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         global $woocommerce;
 
         // Get Order
-        $order = new WC_Order($order_id);
+        $order = wc_get_order($order_id);
+        if (!$order) {
+            return;
+        }
         // Get order items
         $order_items = $order->get_items();
         // Check for offer id
@@ -4763,7 +4784,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
 
                     // Insert WP comment on related 'offer'
                     $comment_text = "<span>" . __('Updated - Status:', 'offers-for-woocommerce') . "</span> " . __('Completed', 'offers-for-woocommerce');
-                    $comment_text .= '<p>' . __('Related Order', 'offers-for-woocommerce') . ': ' . '<a href="post.php?post=' . $order_id . '&action=edit">#' . $order_id . '</a></p>';
+                    $comment_text .= '<p>' . __('Related Order', 'offers-for-woocommerce') . ': ' . '<a href="' . esc_url($this->ofwc_get_order_edit_url($order_id)) . '">#' . $order_id . '</a></p>';
 
                     $comment_data = array(
                         'comment_post_ID' => '',

--- a/includes/angelleye-offers-for-woocommerce-function.php
+++ b/includes/angelleye-offers-for-woocommerce-function.php
@@ -1,5 +1,92 @@
 <?php
 
+if (!function_exists('ofwc_get_product_id')) {
+    /**
+     * Get a product ID using modern WooCommerce APIs with a legacy fallback.
+     *
+     * @param object $product WooCommerce product object.
+     * @return int
+     */
+    function ofwc_get_product_id( $product ) {
+        if ( ! is_object( $product ) ) {
+            return 0;
+        }
+
+        if ( method_exists( $product, 'get_id' ) ) {
+            return (int) $product->get_id();
+        }
+
+        if ( isset( $product->id ) ) {
+            return (int) $product->id;
+        }
+
+        if ( isset( $product->post ) && isset( $product->post->ID ) ) {
+            return (int) $product->post->ID;
+        }
+
+        return 0;
+    }
+}
+
+if (!function_exists('ofwc_get_product_type')) {
+    /**
+     * Get a product type using modern WooCommerce APIs with a legacy fallback.
+     *
+     * @param object $product WooCommerce product object.
+     * @return string
+     */
+    function ofwc_get_product_type( $product ) {
+        if ( ! is_object( $product ) ) {
+            return '';
+        }
+
+        if ( method_exists( $product, 'get_type' ) ) {
+            return (string) $product->get_type();
+        }
+
+        return isset( $product->product_type ) ? (string) $product->product_type : '';
+    }
+}
+
+if (!function_exists('ofwc_get_product_stock_quantity')) {
+    /**
+     * Get stock quantity using the current API with a legacy fallback.
+     *
+     * @param object $product WooCommerce product object.
+     * @return int|null
+     */
+    function ofwc_get_product_stock_quantity( $product ) {
+        if ( ! is_object( $product ) ) {
+            return null;
+        }
+
+        if ( method_exists( $product, 'get_stock_quantity' ) ) {
+            return $product->get_stock_quantity();
+        }
+
+        if ( method_exists( $product, 'get_total_stock' ) ) {
+            return $product->get_total_stock();
+        }
+
+        return null;
+    }
+}
+
+if (!function_exists('ofwc_get_myaccount_page_url')) {
+    /**
+     * Get the My Account page URL using WooCommerce's current helper with a fallback.
+     *
+     * @return string
+     */
+    function ofwc_get_myaccount_page_url() {
+        if ( function_exists( 'wc_get_page_permalink' ) ) {
+            return wc_get_page_permalink( 'myaccount' );
+        }
+
+        return get_permalink( get_option( 'woocommerce_myaccount_page_id' ) );
+    }
+}
+
 if (!function_exists('angelleye_get_vendor_dashboard_page_url')) {
     /**
      * Get vendor dashboard page url.

--- a/includes/angelleye-offers-for-woocommerce-function.php
+++ b/includes/angelleye-offers-for-woocommerce-function.php
@@ -87,6 +87,33 @@ if (!function_exists('ofwc_get_myaccount_page_url')) {
     }
 }
 
+if (!function_exists('ofwc_product_allows_offers')) {
+    /**
+     * Check whether offers are allowed for a product under the current sale-product setting.
+     *
+     * @param object $product WooCommerce product object.
+     * @param array|null $button_options_general Optional general settings array.
+     * @return bool
+     */
+    function ofwc_product_allows_offers( $product, $button_options_general = null ) {
+        if ( ! is_object( $product ) ) {
+            return false;
+        }
+
+        if ( null === $button_options_general ) {
+            $button_options_general = get_option( 'offers_for_woocommerce_options_general' );
+        }
+
+        $disable_offers_for_sale_items = ! empty( $button_options_general['general_setting_disabled_make_offer_on_product_sale'] );
+
+        if ( $disable_offers_for_sale_items && method_exists( $product, 'is_on_sale' ) && $product->is_on_sale() ) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
 if (!function_exists('angelleye_get_vendor_dashboard_page_url')) {
     /**
      * Get vendor dashboard page url.

--- a/offers-for-woocommerce.php
+++ b/offers-for-woocommerce.php
@@ -62,6 +62,13 @@ if (!defined('PAYPAL_FOR_WOOCOMMERCE_PUSH_NOTIFICATION_WEB_URL')) {
  */
 
 /**
+ * Shared plugin helper functions
+ *
+ * @since 0.1.0
+ */
+require_once(plugin_dir_path(__FILE__) . 'includes/angelleye-offers-for-woocommerce-function.php');
+
+/**
  * Require plugin class
  *
  * @since 0.1.0

--- a/public/assets/js/public.js
+++ b/public/assets/js/public.js
@@ -292,7 +292,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     }
                     e.preventDefault();
                     const variation_id = document.querySelector('input[name="variation_id"]');
-                    if (undefined !== variation_id && null !== variation_id && variation_id.value !== 0) {
+                    if (undefined !== variation_id && null !== variation_id && parseInt(variation_id.value, 10) > 0) {
                         offerVariationId = variation_id.value;
                     }
 
@@ -315,9 +315,16 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     var priceField = document.querySelector('.summary .price');
                     var priceBlockField = document.querySelector('.wp-block-woocommerce-product-price .wc-block-components-product-price');
                     if (productType === 'variable') {
-                        var variationPrice = document.querySelector('.woocommerce-variation-price .amount').textContent.replace(/ /g, '');
+                        if (parseInt(offerVariationId, 10) <= 0) {
+                            alert(offers_for_woocommerce_js_params.i18n_make_a_selection_text);
+                            return false;
+                        }
+
+                        var variationPriceElement = document.querySelector('.woocommerce-variation-price .amount');
+                        var variationPrice = variationPriceElement ? variationPriceElement.textContent.replace(/ /g, '') : '';
                         if (variationPrice === '') {
-                            offerProductPrice = document.querySelector('.summary .price .woocommerce-Price-amount').textContent;
+                            var fallbackPriceElement = document.querySelector('.summary .price .woocommerce-Price-amount');
+                            offerProductPrice = fallbackPriceElement ? fallbackPriceElement.textContent : '';
                         } else {
                             offerProductPrice = variationPrice;
                         }

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -3775,7 +3775,10 @@ class Angelleye_Offers_For_Woocommerce {
      */
     public function ofwc_woocommerce_checkout_order_processing( $order_id ) {
 
-        $order = new WC_Order($order_id);
+        $order = wc_get_order($order_id);
+        if (!$order) {
+            return;
+        }
         $order_items = $order->get_items();
 
         if( !empty( $order_items ) ) {

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -1441,6 +1441,30 @@ class Angelleye_Offers_For_Woocommerce {
             $formData['offer_product_price'] = !empty($post['offer_product_price']) ? wc_clean($post['offer_product_price']) : '';
             $formData['offer_total'] = !empty($post['offer_total']) ? Angelleye_Offers_For_Woocommerce_Admin::ofwc_format_localized_price(wc_clean($post['offer_total'])) : '';
 
+            $offer_product = wc_get_product($formData['orig_offer_product_id']);
+            if ($offer_product && $offer_product->is_type('variable')) {
+                $offer_variation_id = absint($formData['orig_offer_variation_id']);
+                $offer_variation = $offer_variation_id ? wc_get_product($offer_variation_id) : false;
+
+                if (
+                    !$offer_variation_id
+                    || !$offer_variation
+                    || !$offer_variation->is_type('variation')
+                    || absint($offer_variation->get_parent_id()) !== absint($formData['orig_offer_product_id'])
+                ) {
+                    if (is_ajax()) {
+                        echo json_encode(array(
+                            "statusmsg" => 'failed-custom',
+                            "statusmsgDetail" => __('Please choose a product variation before submitting your offer.', 'offers-for-woocommerce')
+                        ));
+                        exit;
+                    } else {
+                        $this->set_session('ofwpa_issue', __('Please choose a product variation before submitting your offer.', 'offers-for-woocommerce'));
+                        return false;
+                    }
+                }
+            }
+
             if ($this->is_recaptcha_enable()) {
                 $ofw_recaptcha_version = get_option('ofw_recaptcha_version', 'v2');
                 if ($ofw_recaptcha_version === 'v2') {

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -66,8 +66,6 @@ class Angelleye_Offers_For_Woocommerce {
         if (function_exists('wc')) {
             define('OFWC_PUBLIC_EMAIL_TEMPLATE_PATH', untrailingslashit(plugin_dir_path(__FILE__)) . '/includes/emails/');
 
-            include_once OFFERS_FOR_WOOCOMMERCE_PLUGIN_DIR . '/includes/angelleye-offers-for-woocommerce-function.php';
-
             if (!defined('OFWC_EMAIL_TEMPLATE_PATH')) {
                 define('OFWC_EMAIL_TEMPLATE_PATH', untrailingslashit(OFW_PLUGIN_URL) . '/admin/includes/emails/');
             }
@@ -431,14 +429,7 @@ class Angelleye_Offers_For_Woocommerce {
 	        return null;
         }
 
-        $product_type = '';
-        if (version_compare(WC_VERSION, '3.0', '<')) {
-            if (isset($_product->product_type)) {
-                $product_type = $_product->product_type;
-            }
-        } else {
-            $product_type = $_product->get_type();
-        }
+        $product_type = ofwc_get_product_type($_product);
 
         $is_instock = $_product->is_in_stock();
 
@@ -484,10 +475,10 @@ class Angelleye_Offers_For_Woocommerce {
             if ($req_login) {
                 $redirect_url = '';
                 if ($is_archive) {
-                    $redirect_url = get_permalink(get_option('woocommerce_myaccount_page_id')) . '?ref=make-offer&backto=' . get_permalink($post->ID);
+                    $redirect_url = ofwc_get_myaccount_page_url() . '?ref=make-offer&backto=' . get_permalink($post->ID);
                     $button = '<a href="' . esc_url($redirect_url) . '" id="offers-for-woocommerce-make-offer-button-id-' . esc_attr($post->ID) . '" class="wp-element-button offers-for-woocommerce-make-offer-button-catalog button alt ' . esc_attr($button_class) . ' ' . esc_attr($btn_position_class) . '" style="' . $custom_styles_override . '">' . wp_kses_post( $button_title ) . '</a>';
                 } else {
-                    $redirect_url = get_permalink(get_option('woocommerce_myaccount_page_id')) . '?ref=make-offer&backto=' . home_url(add_query_arg(array(), $wp->request));
+                    $redirect_url = ofwc_get_myaccount_page_url() . '?ref=make-offer&backto=' . home_url(add_query_arg(array(), $wp->request));
                     $button = '<a href="' . esc_url( $redirect_url ) . '"><button type="button" id="offers-for-woocommerce-make-offer-button-id-' . esc_attr( $post->ID ) . '" class="wp-element-button offers-for-woocommerce-make-offer-button-single-product ' . esc_attr( $button_class ) . '  ' . esc_attr( $lightbox_class ) . ' button alt ' . esc_attr( $btn_position_class ) . '" style="' . $custom_styles_override . '">' . wp_kses_post( $button_title ) . '</button></a>';
                 }
             } else {
@@ -667,14 +658,7 @@ class Angelleye_Offers_For_Woocommerce {
             return;
         }
 
-        $product_type = '';
-        if (version_compare(WC_VERSION, '3.0', '<')) {
-            if (isset($_product->product_type)) {
-                $product_type = $_product->product_type;
-            }
-        } else {
-            $product_type = $_product->get_type();
-        }
+        $product_type = ofwc_get_product_type($_product);
 
         $is_lightbox = (isset($button_options_display['display_setting_make_offer_form_display_type']) && $button_options_display['display_setting_make_offer_form_display_type'] === 'lightbox') ? true : false;
         $on_exit_enabled = get_post_meta($post->ID, 'offers_for_woocommerce_onexit_only', true);
@@ -2158,13 +2142,13 @@ class Angelleye_Offers_For_Woocommerce {
                 /**
                  * Lookup Product.
                  */
-                $product = new WC_Product($product_id);
+                $product = wc_get_product($product_id);
 
                 /**
                  * Error - Invalid Product.
                  */
-                $invalid_if_product_id = version_compare(WC_VERSION, '3.0', '<') ? $product->post->ID : $product->get_id();
-                if (!isset($product->post) || $invalid_if_product_id == '' || !is_numeric($product_id)) {
+                $invalid_if_product_id = ofwc_get_product_id($product);
+                if (!$product || $invalid_if_product_id === 0 || !is_numeric($product_id)) {
                     $request_error = true;
                     $this->send_api_response(__('Error - Product Not Found; See shop manager for assistance', 'offers-for-woocommerce'));
                 }
@@ -2208,7 +2192,7 @@ class Angelleye_Offers_For_Woocommerce {
 	        $product_variation_id = isset($offer_meta['orig_offer_variation_id'][0]) ? $offer_meta['orig_offer_variation_id'][0] : '';
 
             $_product = ( $product_variation_id ) ? wc_get_product($product_variation_id) : wc_get_product($product_id);
-            $_product_stock = version_compare(WC_VERSION, '3.0', '<') ? $_product->get_total_stock() : $_product->get_stock_quantity();
+            $_product_stock = ofwc_get_product_stock_quantity($_product);
 
             /**
              * lookup product meta by id or variant id.
@@ -3808,7 +3792,7 @@ class Angelleye_Offers_For_Woocommerce {
         if( !empty( $order_items ) ) {
 
             foreach ($order_items as $key => $value) {
-                $item_offer_id = $order->get_item_meta($key, 'Offer ID', true);
+                $item_offer_id = is_object($value) && method_exists($value, 'get_meta') ? $value->get_meta('Offer ID', true) : $order->get_item_meta($key, 'Offer ID', true);
 
                 if( !function_exists('ofw_manage_offer_single_use')) {
                     require_once( OFW_PLUGIN_URL.'/includes/angelleye-functions.php' );

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -249,7 +249,7 @@ class Angelleye_Offers_For_Woocommerce {
 
         global $product;
 
-        if ($product && $product->is_on_sale()) {
+        if ($product && !ofwc_product_allows_offers($product)) {
             unset($tabs['tab_custom_ofwc_offer']);
         }
 
@@ -425,15 +425,13 @@ class Angelleye_Offers_For_Woocommerce {
             return null;
         }
 
-        if (isset($button_options_general['general_setting_disabled_make_offer_on_product_sale']) && $button_options_general['general_setting_disabled_make_offer_on_product_sale'] == 1 && $_product->is_on_sale()) {
+        if (!ofwc_product_allows_offers($_product, $button_options_general)) {
 	        return null;
         }
 
         $product_type = ofwc_get_product_type($_product);
 
         $is_instock = $_product->is_in_stock();
-        $is_onsale = $_product->is_on_sale();
-
         $custom_tab_options_offers = array(
             'enabled' => get_post_meta($post->ID, 'offers_for_woocommerce_enabled', true),
             'on_exit' => get_post_meta($post->ID, 'offers_for_woocommerce_onexit_only', true),
@@ -446,7 +444,7 @@ class Angelleye_Offers_For_Woocommerce {
             $is_display_offer_button = false;
         }
 
-        if ($custom_tab_options_offers['enabled'] == 'yes' && $is_display_offer_button && $is_instock && !$is_onsale && $custom_tab_options_offers['on_exit'] != 'yes') {
+        if ($custom_tab_options_offers['enabled'] == 'yes' && $is_display_offer_button && $is_instock && $custom_tab_options_offers['on_exit'] != 'yes') {
 
             $button_title = (isset($button_options_display['display_setting_custom_make_offer_btn_text']) && $button_options_display['display_setting_custom_make_offer_btn_text'] != '') ? __($button_options_display['display_setting_custom_make_offer_btn_text'], 'offers-for-woocommerce') : __('Make Offer', 'offers-for-woocommerce');
             $button_title = apply_filters('aeofwc_make_offer_button_label', $button_title);
@@ -659,6 +657,10 @@ class Angelleye_Offers_For_Woocommerce {
             return;
         }
 
+        if (!ofwc_product_allows_offers($_product, $button_options_general)) {
+            return;
+        }
+
         $product_type = ofwc_get_product_type($_product);
 
         $is_lightbox = (isset($button_options_display['display_setting_make_offer_form_display_type']) && $button_options_display['display_setting_make_offer_form_display_type'] === 'lightbox') ? true : false;
@@ -798,7 +800,7 @@ class Angelleye_Offers_For_Woocommerce {
             return $tabs;
         }
 
-        if (isset($button_options_general['general_setting_disabled_make_offer_on_product_sale']) && $button_options_general['general_setting_disabled_make_offer_on_product_sale'] === 1 && $_product->is_on_sale()) {
+        if (!ofwc_product_allows_offers($_product, $button_options_general)) {
             return $tabs;
         }
 
@@ -1427,6 +1429,19 @@ class Angelleye_Offers_For_Woocommerce {
             $formData['offer_total'] = !empty($post['offer_total']) ? Angelleye_Offers_For_Woocommerce_Admin::ofwc_format_localized_price(wc_clean($post['offer_total'])) : '';
 
             $offer_product = wc_get_product($formData['orig_offer_product_id']);
+            if ($offer_product && !ofwc_product_allows_offers($offer_product)) {
+                if (is_ajax()) {
+                    echo json_encode(array(
+                        "statusmsg" => 'failed-custom',
+                        "statusmsgDetail" => __('Offers are not available for sale products.', 'offers-for-woocommerce')
+                    ));
+                    exit;
+                } else {
+                    $this->set_session('ofwpa_issue', __('Offers are not available for sale products.', 'offers-for-woocommerce'));
+                    return false;
+                }
+            }
+
             if ($offer_product && $offer_product->is_type('variable')) {
                 $offer_variation_id = absint($formData['orig_offer_variation_id']);
                 $offer_variation = $offer_variation_id ? wc_get_product($offer_variation_id) : false;

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -441,6 +441,7 @@ class Angelleye_Offers_For_Woocommerce {
         }
 
         $is_instock = $_product->is_in_stock();
+        $is_onsale = $_product->is_on_sale();
 
         $custom_tab_options_offers = array(
             'enabled' => get_post_meta($post->ID, 'offers_for_woocommerce_enabled', true),
@@ -454,7 +455,7 @@ class Angelleye_Offers_For_Woocommerce {
             $is_display_offer_button = false;
         }
 
-        if ($custom_tab_options_offers['enabled'] == 'yes' && $is_display_offer_button && $is_instock && $custom_tab_options_offers['on_exit'] != 'yes') {
+        if ($custom_tab_options_offers['enabled'] == 'yes' && $is_display_offer_button && $is_instock && !$is_onsale && $custom_tab_options_offers['on_exit'] != 'yes') {
 
             $button_title = (isset($button_options_display['display_setting_custom_make_offer_btn_text']) && $button_options_display['display_setting_custom_make_offer_btn_text'] != '') ? __($button_options_display['display_setting_custom_make_offer_btn_text'], 'offers-for-woocommerce') : __('Make Offer', 'offers-for-woocommerce');
             $button_title = apply_filters('aeofwc_make_offer_button_label', $button_title);

--- a/public/views/my-offers.php
+++ b/public/views/my-offers.php
@@ -71,14 +71,8 @@ if ($customer_offers) :
                                         break;
                                     case 'offer_product_title' :                                  
                                         if ($product_title) {
-                                            if(version_compare(WC_VERSION, '3.0', '<')){
-                                                $product_type = $product->product_type;
-                                                $pproduct_id  = $product->id;
-                                            } 
-                                            else{
-                                                $product_type = $product->get_type();
-                                                $pproduct_id  = $product->get_id();
-                                            }
+                                            $product_type = method_exists( $product, 'get_type' ) ? $product->get_type() : ( isset( $product->product_type ) ? $product->product_type : '' );
+                                            $pproduct_id  = method_exists( $product, 'get_id' ) ? $product->get_id() : ( isset( $product->id ) ? $product->id : 0 );
                                             if ($product_type == 'variation') {
                                                 $_product = new WC_Product_Variation($variant_id);
                                                 if(get_post_status($pproduct_id) == 'trash'){

--- a/public/views/public.php
+++ b/public/views/public.php
@@ -65,14 +65,8 @@ if( !empty( $offer_single_use ) ) {
         <fieldset>
             <div class="make-offer-form-intro">
                 <?php
-                if(version_compare(WC_VERSION, '3.0', '<')){
-                    $product = get_product( $post->ID );
-                    $product_id = $product->id;
-                }
-                else{
-                    $product = wc_get_product( $post->ID );
-                    $product_id = $product->get_id();
-                }
+                $product = wc_get_product( $post->ID );
+                $product_id = $product && method_exists( $product, 'get_id' ) ? $product->get_id() : ( isset( $product->id ) ? $product->id : 0 );
                 /* Get Product type */
                 if( $product->is_type( 'variable' ) ){
                     $product_type = 'variable';


### PR DESCRIPTION
# Normalize Sale-Product Offer Behavior

## Summary
Make `general_setting_disabled_make_offer_on_product_sale` the single source of truth for sale-product offer availability across all entrypoints. Current behavior is inconsistent: standard button/tab paths always hide sale products, while lightbox/on-exit and backend submission still allow them.

## Implementation Changes
- Introduce one shared helper in the common helper file that answers: “are offers allowed for this product with current settings?”
- Use that helper in all public entrypoints:
  - standard button rendering
  - custom product tab registration/removal
  - lightbox/on-exit form rendering
  - any frontend form bootstrap logic that derives `sale_product`
  - backend `new_offer_form_submit()` validation
- Define the helper behavior as:
  - if product is not on sale: allow normal existing logic
  - if product is on sale and setting is enabled: block offers consistently
  - if product is on sale and setting is disabled: allow offers consistently
- Remove unconditional sale-product suppression from:
  - `remove_woocommerce_product_tabs()`
  - the hardcoded `!$is_onsale` button condition
- Keep the existing sale-product price handling in JS, but only as pricing logic for allowed sale-product offers.

## Expected Result
- Setting `enabled`:
  - no button
  - no tab
  - no lightbox/on-exit form
  - backend rejects submission for sale products
- Setting `disabled`:
  - sale products behave like non-sale products
  - button/tab/lightbox render normally when other existing conditions pass
  - backend accepts submission

## Test Plan
- Sale product, setting enabled:
  - simple product: no button, no tab, no lightbox/on-exit submit path
  - variable product on sale: same outcome
  - direct AJAX submit for sale product returns a clear validation error
- Sale product, setting disabled:
  - simple product: button/tab/form available under normal existing conditions
  - lightbox/on-exit still works
  - AJAX submit succeeds
- Non-sale product:
  - no behavior regression versus current plugin rules
- Mixed cases:
  - logged-out restrictions
  - role restrictions
  - on-exit only
  - lightbox mode
  - variable product with variation selection

## Assumptions
- Intended product behavior is “disable all offer functionality for sale products” when the setting is on, not just hide one button.
- Backend must enforce the same rule as frontend/UI to prevent bypass.
- Existing sale-product pricing logic in JS is still needed when the setting allows sale-product offers.
