### PR TITLE
Align Offer Submission With Plugin Settings

### DIFF
--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -747,11 +747,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         if (!is_object($_product)) {
             return;
         }
-        if (version_compare(WC_VERSION, '3.0', '<')) {
-            $class_hidden = ( isset($_product->product_type) && $_product->product_type == 'external' ) ? ' custom_tab_offers_for_woocommerce_hidden' : '';
-        } else {
-            $class_hidden = ( $_product->get_type() == 'external' ) ? ' custom_tab_offers_for_woocommerce_hidden' : '';
-        }
+        $class_hidden = ( ofwc_get_product_type($_product) == 'external' ) ? ' custom_tab_offers_for_woocommerce_hidden' : '';
 
         print(
                 '<li id="custom_tab_offers_for_woocommerce" class="custom_tab_offers_for_woocommerce ' . $class_hidden . '"><a href="#custom_tab_data_offers_for_woocommerce"><span>' . __('Offers', 'offers-for-woocommerce') . '</span></a></li>'
@@ -1627,11 +1623,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
 
                         $_product_managing_stock = ( $_product_variant->managing_stock() ) ? $_product_variant->managing_stock() : $_product->managing_stock();
 
-                        if (version_compare(WC_VERSION, '3.0', '<')) {
-                            $_product_stock = ( $_product_variant_managing_stock ) ? $_product_variant->get_total_stock() : $_product->get_total_stock();
-                        } else {
-                            $_product_stock = ( $_product_variant_managing_stock ) ? $_product_variant->get_stock_quantity() : $_product->get_stock_quantity();
-                        }
+                        $_product_stock = ( $_product_variant_managing_stock ) ? ofwc_get_product_stock_quantity($_product_variant) : ofwc_get_product_stock_quantity($_product);
 
                         $_product_in_stock = ( $_product_variant_managing_stock ) ? $_product_variant->has_enough_stock($postmeta['offer_quantity'][0]) : $_product->has_enough_stock($postmeta['offer_quantity'][0]);
                         $_product_backorders_allowed = ( $_product_variant_managing_stock ) ? $_product_variant->backorders_allowed() : $_product->backorders_allowed();
@@ -1645,7 +1637,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
                         $_product_regular_price = $_product->get_regular_price();
                         $_product_sale_price = $_product->get_sale_price();
                         $_product_managing_stock = $_product->managing_stock();
-                        $_product_stock = version_compare(WC_VERSION, '3.0', '<') ? $_product->get_total_stock() : $_product->get_stock_quantity();
+                        $_product_stock = ofwc_get_product_stock_quantity($_product);
                         $_product_in_stock = $_product->has_enough_stock($postmeta['offer_quantity'][0]);
                         $_product_backorders_allowed = $_product->backorders_allowed();
                         $_product_backorders_require_notification = $_product->backorders_require_notification();
@@ -1656,7 +1648,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
                     }
 
                     /* Products Addon and Offers Plugin meta check starts */
-                    $product_addon_id = version_compare(WC_VERSION, '3.0', '<') ? $_product->post->ID : $_product->get_id();
+                    $product_addon_id = ofwc_get_product_id($_product);
                     $_product_addons_data = get_post_meta($product_addon_id, '_product_addons', true);
                     /* Products Addon and Offers Plugin meta check end. */
 
@@ -4096,7 +4088,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
      */
     public function woocommerce_product_quick_edit_save_own($product) {
 
-        $post_id = version_compare(WC_VERSION, '3.0', '<') ? $product->id : $product->get_id();
+        $post_id = ofwc_get_product_id($product);
 
         $offers_for_woocommerce_enabled = (isset($_REQUEST['offers_for_woocommerce_enabled']) && $_REQUEST['offers_for_woocommerce_enabled'] == 'yes') ? 'yes' : 'no';
         $offers_for_woocommerce_auto_accept_enabled = (isset($_REQUEST['_offers_for_woocommerce_auto_accept_enabled']) && $_REQUEST['_offers_for_woocommerce_auto_accept_enabled'] == 'yes' ) ? 'yes' : 'no';
@@ -4762,7 +4754,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         $order_items = $order->get_items();
         // Check for offer id
         foreach ($order_items as $key => $value) {
-            $item_offer_id = wc_get_order_item_meta( $key, 'Offer ID',true );
+            $item_offer_id = is_object($value) && method_exists($value, 'get_meta') ? $value->get_meta('Offer ID', true) : wc_get_order_item_meta($key, 'Offer ID', true);
             /**
              * Update offer
              * Add postmeta value 'offer_order_id' for this order id

--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -578,7 +578,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
             $ofw_adp = get_post_meta($postid, '_offers_for_woocommerce_auto_decline_percentage', true);
 	        $ofw_adp = ($ofw_adp) ? $ofw_adp : '';
 
-            $button_options_general = get_option('offers_for_woocommerce_options_general');
+            $button_options_general = ofwc_get_general_settings();
             if (isset($button_options_general['general_setting_enable_offers_by_default']) && $button_options_general['general_setting_enable_offers_by_default'] == '1') {
                 $ofw_enabled = 'yes';
             }
@@ -770,7 +770,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         $post_meta_offers_enabled = get_post_meta($post->ID, 'offers_for_woocommerce_enabled', true);
         $field_value = 'yes';
         $field_callback = ($post_meta_offers_enabled) ?: 'no';
-        $button_options_general = get_option('offers_for_woocommerce_options_general');
+        $button_options_general = ofwc_get_general_settings();
         if ($pagenow == 'post-new.php' && isset($button_options_general['general_setting_enable_offers_by_default'])) {
             if ($button_options_general['general_setting_enable_offers_by_default'] == '1') {
                 $field_callback = 'yes';
@@ -1659,7 +1659,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
                     if ($current_status_value == 'publish') {
                         // get offers options - general
                         $default_expire_date = '';
-                        $options_general = get_option('offers_for_woocommerce_options_general');
+                        $options_general = ofwc_get_general_settings();
                         if (!empty($options_general['general_setting_default_expire_days'])) {
                             $current_time = date("Y-m-d H:i:s", current_time('timestamp', 0));
                             $default_expire_days = str_replace(",", "", $options_general['general_setting_default_expire_days']);
@@ -2079,9 +2079,10 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         );
 
         //check to see if present already
-        if (!get_option('offers_for_woocommerce_options_general')) {
+        if (!ofwc_get_general_settings()) {
             //option not found, add new
             add_option('offers_for_woocommerce_options_general', $offers_for_woocommerce_options_general);
+            ofwc_get_general_settings(true);
         }
 
         /**
@@ -2097,15 +2098,17 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         );
 
         //this will check for the setting after version update.
-        $admin_button_options_display = get_option('offers_for_woocommerce_options_display');
+        $admin_button_options_display = ofwc_get_display_settings();
         if (!isset($admin_button_options_display['display_setting_make_offer_button_position_single'])) {
             update_option('offers_for_woocommerce_options_display', $offers_for_woocommerce_options_display);
+            $admin_button_options_display = ofwc_get_display_settings(true);
         }
 
         //check to see if present already
-        if (!get_option('offers_for_woocommerce_options_display')) {
+        if (!ofwc_get_display_settings()) {
             //option not found, add new
             add_option('offers_for_woocommerce_options_display', $offers_for_woocommerce_options_display);
+            ofwc_get_display_settings(true);
         }
 
         $angelleye_displaySettingFormFieldPosition = array(
@@ -4399,7 +4402,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
      * @return bool
      */
     public function ofw_is_anonymous_communication_enable() {
-        $offers_for_woocommerce_options_general = get_option('offers_for_woocommerce_options_general');
+        $offers_for_woocommerce_options_general = ofwc_get_general_settings();
         if (isset($offers_for_woocommerce_options_general['general_setting_enable_anonymous_communication']) && $offers_for_woocommerce_options_general['general_setting_enable_anonymous_communication'] == 1) {
             return true;
         }
@@ -4447,7 +4450,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
      * @return bool
      */
     public function ofw_is_show_pending_offer_enable() {
-        $offers_for_woocommerce_options_general = get_option('offers_for_woocommerce_options_general');
+        $offers_for_woocommerce_options_general = ofwc_get_general_settings();
         if (isset($offers_for_woocommerce_options_general['general_setting_show_pending_offer']) && $offers_for_woocommerce_options_general['general_setting_show_pending_offer'] == 1) {
             return true;
         }
@@ -4990,7 +4993,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         }
         wp_enqueue_script('wc-enhanced-select');
         wp_enqueue_style('woocommerce_admin_styles');
-        $button_display_options = get_option('offers_for_woocommerce_options_display');
+        $button_display_options = ofwc_get_display_settings();
         $button_display_position = get_option('angelleye_displaySettingFormFieldPosition');
         $user_string = '';
         $user_id = '';

--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -35,6 +35,26 @@ class Angelleye_Offers_For_Woocommerce_Admin {
     protected $plugin_screen_hook_suffix = null;
 
     /**
+     * Build an admin edit URL for a WooCommerce order that works with both legacy storage and HPOS.
+     *
+     * @param int $order_id Order ID.
+     * @return string
+     */
+    private function ofwc_get_order_edit_url($order_id) {
+        $order_id = absint($order_id);
+
+        if (
+            function_exists('wc_get_container')
+            && class_exists('\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController')
+            && wc_get_container()->get(\Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class)->custom_orders_table_usage_is_enabled()
+        ) {
+            return admin_url('admin.php?page=wc-orders&action=edit&id=' . $order_id);
+        }
+
+        return admin_url('post.php?post=' . $order_id . '&action=edit');
+    }
+
+    /**
      * Initialize the plugin by loading admin scripts & styles and adding a settings page and menu
      * @since     0.1.0
      */
@@ -1667,19 +1687,17 @@ class Angelleye_Offers_For_Woocommerce_Admin {
 
                         // Set order meta data array
 
-                        $offer_order_meta['Order ID'] = '<a href="post.php?post=' . $order_id . '&action=edit">' . '#' . $order_id . '</a>';
+                        $offer_order_meta['Order ID'] = '<a href="' . esc_url($this->ofwc_get_order_edit_url($order_id)) . '">#' . $order_id . '</a>';
 
                         // Get Order
-                        $order = new WC_Order($order_id);
-                        if ($order->post) {
-                            $offer_order_meta['Order Date'] = $order->post->post_date;
+                        $order = wc_get_order($order_id);
+                        if ($order) {
+                            $order_date = $order->get_date_created();
+                            $offer_order_meta['Order Date'] = $order_date ? $order_date->date_i18n('Y-m-d H:i:s') : '';
                             $offer_order_meta['Order Status'] = ucwords($order->get_status());
                         } else {
                             $offer_order_meta['Order ID'] .= '<br /><small><strong>Notice: </strong>' . __('Order not found; may have been deleted', 'offers-for-woocommerce') . '</small>';
                         }
-
-                        $offer_order_meta['Order Date'] = $order->post->post_date;
-                        $offer_order_meta['Order Status'] = ucwords($order->get_status());
                     } else {
                         $offer_order_meta['Order ID'] = '<br /><small><strong>Notice: </strong>' . __('Order not found; may have been deleted', 'offers-for-woocommerce') . '</small>';
                     }
@@ -4736,7 +4754,10 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         global $woocommerce;
 
         // Get Order
-        $order = new WC_Order($order_id);
+        $order = wc_get_order($order_id);
+        if (!$order) {
+            return;
+        }
         // Get order items
         $order_items = $order->get_items();
         // Check for offer id
@@ -4763,7 +4784,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
 
                     // Insert WP comment on related 'offer'
                     $comment_text = "<span>" . __('Updated - Status:', 'offers-for-woocommerce') . "</span> " . __('Completed', 'offers-for-woocommerce');
-                    $comment_text .= '<p>' . __('Related Order', 'offers-for-woocommerce') . ': ' . '<a href="post.php?post=' . $order_id . '&action=edit">#' . $order_id . '</a></p>';
+                    $comment_text .= '<p>' . __('Related Order', 'offers-for-woocommerce') . ': ' . '<a href="' . esc_url($this->ofwc_get_order_edit_url($order_id)) . '">#' . $order_id . '</a></p>';
 
                     $comment_data = array(
                         'comment_post_ID' => '',

--- a/includes/angelleye-offers-for-woocommerce-function.php
+++ b/includes/angelleye-offers-for-woocommerce-function.php
@@ -1,5 +1,92 @@
 <?php
 
+if (!function_exists('ofwc_get_product_id')) {
+    /**
+     * Get a product ID using modern WooCommerce APIs with a legacy fallback.
+     *
+     * @param object $product WooCommerce product object.
+     * @return int
+     */
+    function ofwc_get_product_id( $product ) {
+        if ( ! is_object( $product ) ) {
+            return 0;
+        }
+
+        if ( method_exists( $product, 'get_id' ) ) {
+            return (int) $product->get_id();
+        }
+
+        if ( isset( $product->id ) ) {
+            return (int) $product->id;
+        }
+
+        if ( isset( $product->post ) && isset( $product->post->ID ) ) {
+            return (int) $product->post->ID;
+        }
+
+        return 0;
+    }
+}
+
+if (!function_exists('ofwc_get_product_type')) {
+    /**
+     * Get a product type using modern WooCommerce APIs with a legacy fallback.
+     *
+     * @param object $product WooCommerce product object.
+     * @return string
+     */
+    function ofwc_get_product_type( $product ) {
+        if ( ! is_object( $product ) ) {
+            return '';
+        }
+
+        if ( method_exists( $product, 'get_type' ) ) {
+            return (string) $product->get_type();
+        }
+
+        return isset( $product->product_type ) ? (string) $product->product_type : '';
+    }
+}
+
+if (!function_exists('ofwc_get_product_stock_quantity')) {
+    /**
+     * Get stock quantity using the current API with a legacy fallback.
+     *
+     * @param object $product WooCommerce product object.
+     * @return int|null
+     */
+    function ofwc_get_product_stock_quantity( $product ) {
+        if ( ! is_object( $product ) ) {
+            return null;
+        }
+
+        if ( method_exists( $product, 'get_stock_quantity' ) ) {
+            return $product->get_stock_quantity();
+        }
+
+        if ( method_exists( $product, 'get_total_stock' ) ) {
+            return $product->get_total_stock();
+        }
+
+        return null;
+    }
+}
+
+if (!function_exists('ofwc_get_myaccount_page_url')) {
+    /**
+     * Get the My Account page URL using WooCommerce's current helper with a fallback.
+     *
+     * @return string
+     */
+    function ofwc_get_myaccount_page_url() {
+        if ( function_exists( 'wc_get_page_permalink' ) ) {
+            return wc_get_page_permalink( 'myaccount' );
+        }
+
+        return get_permalink( get_option( 'woocommerce_myaccount_page_id' ) );
+    }
+}
+
 if (!function_exists('angelleye_get_vendor_dashboard_page_url')) {
     /**
      * Get vendor dashboard page url.

--- a/includes/angelleye-offers-for-woocommerce-function.php
+++ b/includes/angelleye-offers-for-woocommerce-function.php
@@ -87,6 +87,33 @@ if (!function_exists('ofwc_get_myaccount_page_url')) {
     }
 }
 
+if (!function_exists('ofwc_product_allows_offers')) {
+    /**
+     * Check whether offers are allowed for a product under the current sale-product setting.
+     *
+     * @param object $product WooCommerce product object.
+     * @param array|null $button_options_general Optional general settings array.
+     * @return bool
+     */
+    function ofwc_product_allows_offers( $product, $button_options_general = null ) {
+        if ( ! is_object( $product ) ) {
+            return false;
+        }
+
+        if ( null === $button_options_general ) {
+            $button_options_general = get_option( 'offers_for_woocommerce_options_general' );
+        }
+
+        $disable_offers_for_sale_items = ! empty( $button_options_general['general_setting_disabled_make_offer_on_product_sale'] );
+
+        if ( $disable_offers_for_sale_items && method_exists( $product, 'is_on_sale' ) && $product->is_on_sale() ) {
+            return false;
+        }
+
+        return true;
+    }
+}
+
 if (!function_exists('angelleye_get_vendor_dashboard_page_url')) {
     /**
      * Get vendor dashboard page url.

--- a/includes/angelleye-offers-for-woocommerce-function.php
+++ b/includes/angelleye-offers-for-woocommerce-function.php
@@ -1,5 +1,47 @@
 <?php
 
+if (!function_exists('ofwc_get_general_settings')) {
+    /**
+     * Get general plugin settings with request-scoped memoization.
+     *
+     * @param bool $force_refresh Force a fresh read from the options table.
+     * @return array
+     */
+    function ofwc_get_general_settings( $force_refresh = false ) {
+        static $settings = null;
+
+        if ($force_refresh || null === $settings) {
+            $settings = get_option('offers_for_woocommerce_options_general', array());
+            if (!is_array($settings)) {
+                $settings = array();
+            }
+        }
+
+        return $settings;
+    }
+}
+
+if (!function_exists('ofwc_get_display_settings')) {
+    /**
+     * Get display plugin settings with request-scoped memoization.
+     *
+     * @param bool $force_refresh Force a fresh read from the options table.
+     * @return array
+     */
+    function ofwc_get_display_settings( $force_refresh = false ) {
+        static $settings = null;
+
+        if ($force_refresh || null === $settings) {
+            $settings = get_option('offers_for_woocommerce_options_display', array());
+            if (!is_array($settings)) {
+                $settings = array();
+            }
+        }
+
+        return $settings;
+    }
+}
+
 if (!function_exists('ofwc_get_product_id')) {
     /**
      * Get a product ID using modern WooCommerce APIs with a legacy fallback.
@@ -101,7 +143,7 @@ if (!function_exists('ofwc_product_allows_offers')) {
         }
 
         if ( null === $button_options_general ) {
-            $button_options_general = get_option( 'offers_for_woocommerce_options_general' );
+            $button_options_general = ofwc_get_general_settings();
         }
 
         $disable_offers_for_sale_items = ! empty( $button_options_general['general_setting_disabled_make_offer_on_product_sale'] );
@@ -111,6 +153,76 @@ if (!function_exists('ofwc_product_allows_offers')) {
         }
 
         return true;
+    }
+}
+
+if (!function_exists('ofwc_current_user_can_submit_offers')) {
+    /**
+     * Check whether the current user is allowed to submit offers.
+     *
+     * @param array|null $button_options_general Optional general settings array.
+     * @return true|\WP_Error
+     */
+    function ofwc_current_user_can_submit_offers( $button_options_general = null ) {
+        if ( null === $button_options_general ) {
+            $button_options_general = ofwc_get_general_settings();
+        }
+
+        if ( ! empty( $button_options_general['general_setting_enable_offers_only_logged_in_users'] ) && ! is_user_logged_in() ) {
+            return new WP_Error( 'login_required', __( 'Please log in to submit an offer.', 'offers-for-woocommerce' ) );
+        }
+
+        if ( ! empty( $button_options_general['general_setting_allowed_roles'] ) ) {
+            if ( ! is_user_logged_in() ) {
+                return new WP_Error( 'role_not_allowed', __( 'You are not allowed to submit offers.', 'offers-for-woocommerce' ) );
+            }
+
+            $current_user = wp_get_current_user();
+            $user_roles   = ! empty( $current_user->roles ) ? (array) $current_user->roles : array();
+            $allowed      = array_intersect( $user_roles, (array) $button_options_general['general_setting_allowed_roles'] );
+
+            if ( empty( $allowed ) ) {
+                return new WP_Error( 'role_not_allowed', __( 'You are not allowed to submit offers.', 'offers-for-woocommerce' ) );
+            }
+        }
+
+        return true;
+    }
+}
+
+if (!function_exists('ofwc_is_supported_offer_product_type')) {
+    /**
+     * Check whether a product type supports offer submission.
+     *
+     * @param object $product WooCommerce product object.
+     * @return bool
+     */
+    function ofwc_is_supported_offer_product_type( $product ) {
+        $product_type = ofwc_get_product_type( $product );
+
+        return in_array( $product_type, array( 'simple', 'variable' ), true );
+    }
+}
+
+if (!function_exists('ofwc_get_required_offer_form_fields')) {
+    /**
+     * Get the required offer form fields from display settings.
+     *
+     * @param array|null $button_display_options Optional display settings array.
+     * @return array
+     */
+    function ofwc_get_required_offer_form_fields( $button_display_options = null ) {
+        if ( null === $button_display_options ) {
+            $button_display_options = ofwc_get_display_settings();
+        }
+
+        return array(
+            'offer_name'         => true,
+            'offer_email'        => true,
+            'offer_company_name' => ! empty( $button_display_options['display_setting_make_offer_form_field_offer_company_name'] ) && ! empty( $button_display_options['display_setting_make_offer_form_field_offer_company_name_required'] ),
+            'offer_phone'        => ! empty( $button_display_options['display_setting_make_offer_form_field_offer_phone'] ) && ! empty( $button_display_options['display_setting_make_offer_form_field_offer_phone_required'] ),
+            'offer_notes'        => ! empty( $button_display_options['display_setting_make_offer_form_field_offer_notes'] ) && ! empty( $button_display_options['display_setting_make_offer_form_field_offer_notes_required'] ),
+        );
     }
 }
 

--- a/offers-for-woocommerce.php
+++ b/offers-for-woocommerce.php
@@ -62,6 +62,13 @@ if (!defined('PAYPAL_FOR_WOOCOMMERCE_PUSH_NOTIFICATION_WEB_URL')) {
  */
 
 /**
+ * Shared plugin helper functions
+ *
+ * @since 0.1.0
+ */
+require_once(plugin_dir_path(__FILE__) . 'includes/angelleye-offers-for-woocommerce-function.php');
+
+/**
  * Require plugin class
  *
  * @since 0.1.0

--- a/public/assets/js/public.js
+++ b/public/assets/js/public.js
@@ -292,7 +292,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     }
                     e.preventDefault();
                     const variation_id = document.querySelector('input[name="variation_id"]');
-                    if (undefined !== variation_id && null !== variation_id && variation_id.value !== 0) {
+                    if (undefined !== variation_id && null !== variation_id && parseInt(variation_id.value, 10) > 0) {
                         offerVariationId = variation_id.value;
                     }
 
@@ -315,9 +315,16 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     var priceField = document.querySelector('.summary .price');
                     var priceBlockField = document.querySelector('.wp-block-woocommerce-product-price .wc-block-components-product-price');
                     if (productType === 'variable') {
-                        var variationPrice = document.querySelector('.woocommerce-variation-price .amount').textContent.replace(/ /g, '');
+                        if (parseInt(offerVariationId, 10) <= 0) {
+                            alert(offers_for_woocommerce_js_params.i18n_make_a_selection_text);
+                            return false;
+                        }
+
+                        var variationPriceElement = document.querySelector('.woocommerce-variation-price .amount');
+                        var variationPrice = variationPriceElement ? variationPriceElement.textContent.replace(/ /g, '') : '';
                         if (variationPrice === '') {
-                            offerProductPrice = document.querySelector('.summary .price .woocommerce-Price-amount').textContent;
+                            var fallbackPriceElement = document.querySelector('.summary .price .woocommerce-Price-amount');
+                            offerProductPrice = fallbackPriceElement ? fallbackPriceElement.textContent : '';
                         } else {
                             offerProductPrice = variationPrice;
                         }

--- a/public/assets/js/public.js
+++ b/public/assets/js/public.js
@@ -678,32 +678,42 @@ document.addEventListener("DOMContentLoaded", function (event) {
             }
         });
 
-        /*offer quantity input keyup*/
-        $('#woocommerce-make-offer-form-quantity').keyup(function () {
-            updateTotal();
-        });
+        var offerQuantityField = $('#woocommerce-make-offer-form-quantity');
+        var offerPriceEachField = $('#woocommerce-make-offer-form-price-each');
+        var offerTotalField = $('#woocommerce-make-offer-form-total');
 
-        /*offer price each input keyup*/
-        $('#woocommerce-make-offer-form-price-each').keyup(function () {
-            updateTotal();
-        });
+        /*offer quantity input keyup*/
+        if (offerQuantityField.length && offerPriceEachField.length && offerTotalField.length) {
+            offerQuantityField.on('keyup', function () {
+                updateTotal();
+            });
+
+            /*offer price each input keyup*/
+            offerPriceEachField.on('keyup', function () {
+                updateTotal();
+            });
+        }
 
         /*Update totals*/
         var updateTotal = function () {
-            var input1 = $('#woocommerce-make-offer-form-quantity').autoNumerics('get');
-            var input2 = $('#woocommerce-make-offer-form-price-each').autoNumerics('get');
+            if (!offerQuantityField.length || !offerPriceEachField.length || !offerTotalField.length) {
+                return;
+            }
+
+            var input1 = offerQuantityField.autoNumerics('get');
+            var input2 = offerPriceEachField.autoNumerics('get');
             if (isNaN(input1) || isNaN(input2)) {
-                document.getElementById('woocommerce-make-offer-form-total').value = '';
+                offerTotalField.val('');
             } else {
                 var theTotal = (input1 * input2);
-                var currencySymbol = document.getElementById('woocommerce-make-offer-form-total').getAttribute('data-currency-symbol');
+                var currencySymbol = offerTotalField.attr('data-currency-symbol');
                 if (!currencySymbol) {
                     currencySymbol = '$';
                 }
 
-                $('#woocommerce-make-offer-form-total').autoNumerics('set', theTotal);
+                offerTotalField.autoNumerics('set', theTotal);
 
-                $('#woocommerce-make-offer-form-total').autoNumerics('update', {
+                offerTotalField.autoNumerics('update', {
                     aForm: false, /* Controls if default values are formatted on page ready (load) */
                     aSep: offers_for_woocommerce_js_params.ofw_public_js_thousand_separator, /* Thousand separator */
                     aDec: offers_for_woocommerce_js_params.ofw_public_js_decimal_separator, /* Decimal separator */
@@ -730,8 +740,9 @@ document.addEventListener("DOMContentLoaded", function (event) {
         }
     });
 
-    document.addEventListener('DOMContentLoaded', function () {
-        document.getElementById('common-click-to-pay').addEventListener('click', function () {
+    var commonClickToPay = document.getElementById('common-click-to-pay');
+    if (commonClickToPay) {
+        commonClickToPay.addEventListener('click', function () {
             var checkboxes = document.querySelectorAll('.offer-checkbox:checked');
             var urls = [];
 
@@ -761,5 +772,5 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 alert('Please select at least one offer.');
             }
         });
-    });
+    }
 }(jQuery));

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -3775,7 +3775,10 @@ class Angelleye_Offers_For_Woocommerce {
      */
     public function ofwc_woocommerce_checkout_order_processing( $order_id ) {
 
-        $order = new WC_Order($order_id);
+        $order = wc_get_order($order_id);
+        if (!$order) {
+            return;
+        }
         $order_items = $order->get_items();
 
         if( !empty( $order_items ) ) {

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -1441,6 +1441,30 @@ class Angelleye_Offers_For_Woocommerce {
             $formData['offer_product_price'] = !empty($post['offer_product_price']) ? wc_clean($post['offer_product_price']) : '';
             $formData['offer_total'] = !empty($post['offer_total']) ? Angelleye_Offers_For_Woocommerce_Admin::ofwc_format_localized_price(wc_clean($post['offer_total'])) : '';
 
+            $offer_product = wc_get_product($formData['orig_offer_product_id']);
+            if ($offer_product && $offer_product->is_type('variable')) {
+                $offer_variation_id = absint($formData['orig_offer_variation_id']);
+                $offer_variation = $offer_variation_id ? wc_get_product($offer_variation_id) : false;
+
+                if (
+                    !$offer_variation_id
+                    || !$offer_variation
+                    || !$offer_variation->is_type('variation')
+                    || absint($offer_variation->get_parent_id()) !== absint($formData['orig_offer_product_id'])
+                ) {
+                    if (is_ajax()) {
+                        echo json_encode(array(
+                            "statusmsg" => 'failed-custom',
+                            "statusmsgDetail" => __('Please choose a product variation before submitting your offer.', 'offers-for-woocommerce')
+                        ));
+                        exit;
+                    } else {
+                        $this->set_session('ofwpa_issue', __('Please choose a product variation before submitting your offer.', 'offers-for-woocommerce'));
+                        return false;
+                    }
+                }
+            }
+
             if ($this->is_recaptcha_enable()) {
                 $ofw_recaptcha_version = get_option('ofw_recaptcha_version', 'v2');
                 if ($ofw_recaptcha_version === 'v2') {

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -66,8 +66,6 @@ class Angelleye_Offers_For_Woocommerce {
         if (function_exists('wc')) {
             define('OFWC_PUBLIC_EMAIL_TEMPLATE_PATH', untrailingslashit(plugin_dir_path(__FILE__)) . '/includes/emails/');
 
-            include_once OFFERS_FOR_WOOCOMMERCE_PLUGIN_DIR . '/includes/angelleye-offers-for-woocommerce-function.php';
-
             if (!defined('OFWC_EMAIL_TEMPLATE_PATH')) {
                 define('OFWC_EMAIL_TEMPLATE_PATH', untrailingslashit(OFW_PLUGIN_URL) . '/admin/includes/emails/');
             }
@@ -431,14 +429,7 @@ class Angelleye_Offers_For_Woocommerce {
 	        return null;
         }
 
-        $product_type = '';
-        if (version_compare(WC_VERSION, '3.0', '<')) {
-            if (isset($_product->product_type)) {
-                $product_type = $_product->product_type;
-            }
-        } else {
-            $product_type = $_product->get_type();
-        }
+        $product_type = ofwc_get_product_type($_product);
 
         $is_instock = $_product->is_in_stock();
 
@@ -484,10 +475,10 @@ class Angelleye_Offers_For_Woocommerce {
             if ($req_login) {
                 $redirect_url = '';
                 if ($is_archive) {
-                    $redirect_url = get_permalink(get_option('woocommerce_myaccount_page_id')) . '?ref=make-offer&backto=' . get_permalink($post->ID);
+                    $redirect_url = ofwc_get_myaccount_page_url() . '?ref=make-offer&backto=' . get_permalink($post->ID);
                     $button = '<a href="' . esc_url($redirect_url) . '" id="offers-for-woocommerce-make-offer-button-id-' . esc_attr($post->ID) . '" class="wp-element-button offers-for-woocommerce-make-offer-button-catalog button alt ' . esc_attr($button_class) . ' ' . esc_attr($btn_position_class) . '" style="' . $custom_styles_override . '">' . wp_kses_post( $button_title ) . '</a>';
                 } else {
-                    $redirect_url = get_permalink(get_option('woocommerce_myaccount_page_id')) . '?ref=make-offer&backto=' . home_url(add_query_arg(array(), $wp->request));
+                    $redirect_url = ofwc_get_myaccount_page_url() . '?ref=make-offer&backto=' . home_url(add_query_arg(array(), $wp->request));
                     $button = '<a href="' . esc_url( $redirect_url ) . '"><button type="button" id="offers-for-woocommerce-make-offer-button-id-' . esc_attr( $post->ID ) . '" class="wp-element-button offers-for-woocommerce-make-offer-button-single-product ' . esc_attr( $button_class ) . '  ' . esc_attr( $lightbox_class ) . ' button alt ' . esc_attr( $btn_position_class ) . '" style="' . $custom_styles_override . '">' . wp_kses_post( $button_title ) . '</button></a>';
                 }
             } else {
@@ -667,14 +658,7 @@ class Angelleye_Offers_For_Woocommerce {
             return;
         }
 
-        $product_type = '';
-        if (version_compare(WC_VERSION, '3.0', '<')) {
-            if (isset($_product->product_type)) {
-                $product_type = $_product->product_type;
-            }
-        } else {
-            $product_type = $_product->get_type();
-        }
+        $product_type = ofwc_get_product_type($_product);
 
         $is_lightbox = (isset($button_options_display['display_setting_make_offer_form_display_type']) && $button_options_display['display_setting_make_offer_form_display_type'] === 'lightbox') ? true : false;
         $on_exit_enabled = get_post_meta($post->ID, 'offers_for_woocommerce_onexit_only', true);
@@ -2158,13 +2142,13 @@ class Angelleye_Offers_For_Woocommerce {
                 /**
                  * Lookup Product.
                  */
-                $product = new WC_Product($product_id);
+                $product = wc_get_product($product_id);
 
                 /**
                  * Error - Invalid Product.
                  */
-                $invalid_if_product_id = version_compare(WC_VERSION, '3.0', '<') ? $product->post->ID : $product->get_id();
-                if (!isset($product->post) || $invalid_if_product_id == '' || !is_numeric($product_id)) {
+                $invalid_if_product_id = ofwc_get_product_id($product);
+                if (!$product || $invalid_if_product_id === 0 || !is_numeric($product_id)) {
                     $request_error = true;
                     $this->send_api_response(__('Error - Product Not Found; See shop manager for assistance', 'offers-for-woocommerce'));
                 }
@@ -2208,7 +2192,7 @@ class Angelleye_Offers_For_Woocommerce {
 	        $product_variation_id = isset($offer_meta['orig_offer_variation_id'][0]) ? $offer_meta['orig_offer_variation_id'][0] : '';
 
             $_product = ( $product_variation_id ) ? wc_get_product($product_variation_id) : wc_get_product($product_id);
-            $_product_stock = version_compare(WC_VERSION, '3.0', '<') ? $_product->get_total_stock() : $_product->get_stock_quantity();
+            $_product_stock = ofwc_get_product_stock_quantity($_product);
 
             /**
              * lookup product meta by id or variant id.
@@ -3808,7 +3792,7 @@ class Angelleye_Offers_For_Woocommerce {
         if( !empty( $order_items ) ) {
 
             foreach ($order_items as $key => $value) {
-                $item_offer_id = $order->get_item_meta($key, 'Offer ID', true);
+                $item_offer_id = is_object($value) && method_exists($value, 'get_meta') ? $value->get_meta('Offer ID', true) : $order->get_item_meta($key, 'Offer ID', true);
 
                 if( !function_exists('ofw_manage_offer_single_use')) {
                     require_once( OFW_PLUGIN_URL.'/includes/angelleye-functions.php' );

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -249,7 +249,7 @@ class Angelleye_Offers_For_Woocommerce {
 
         global $product;
 
-        if ($product && $product->is_on_sale()) {
+        if ($product && !ofwc_product_allows_offers($product)) {
             unset($tabs['tab_custom_ofwc_offer']);
         }
 
@@ -425,15 +425,13 @@ class Angelleye_Offers_For_Woocommerce {
             return null;
         }
 
-        if (isset($button_options_general['general_setting_disabled_make_offer_on_product_sale']) && $button_options_general['general_setting_disabled_make_offer_on_product_sale'] == 1 && $_product->is_on_sale()) {
+        if (!ofwc_product_allows_offers($_product, $button_options_general)) {
 	        return null;
         }
 
         $product_type = ofwc_get_product_type($_product);
 
         $is_instock = $_product->is_in_stock();
-        $is_onsale = $_product->is_on_sale();
-
         $custom_tab_options_offers = array(
             'enabled' => get_post_meta($post->ID, 'offers_for_woocommerce_enabled', true),
             'on_exit' => get_post_meta($post->ID, 'offers_for_woocommerce_onexit_only', true),
@@ -446,7 +444,7 @@ class Angelleye_Offers_For_Woocommerce {
             $is_display_offer_button = false;
         }
 
-        if ($custom_tab_options_offers['enabled'] == 'yes' && $is_display_offer_button && $is_instock && !$is_onsale && $custom_tab_options_offers['on_exit'] != 'yes') {
+        if ($custom_tab_options_offers['enabled'] == 'yes' && $is_display_offer_button && $is_instock && $custom_tab_options_offers['on_exit'] != 'yes') {
 
             $button_title = (isset($button_options_display['display_setting_custom_make_offer_btn_text']) && $button_options_display['display_setting_custom_make_offer_btn_text'] != '') ? __($button_options_display['display_setting_custom_make_offer_btn_text'], 'offers-for-woocommerce') : __('Make Offer', 'offers-for-woocommerce');
             $button_title = apply_filters('aeofwc_make_offer_button_label', $button_title);
@@ -659,6 +657,10 @@ class Angelleye_Offers_For_Woocommerce {
             return;
         }
 
+        if (!ofwc_product_allows_offers($_product, $button_options_general)) {
+            return;
+        }
+
         $product_type = ofwc_get_product_type($_product);
 
         $is_lightbox = (isset($button_options_display['display_setting_make_offer_form_display_type']) && $button_options_display['display_setting_make_offer_form_display_type'] === 'lightbox') ? true : false;
@@ -798,7 +800,7 @@ class Angelleye_Offers_For_Woocommerce {
             return $tabs;
         }
 
-        if (isset($button_options_general['general_setting_disabled_make_offer_on_product_sale']) && $button_options_general['general_setting_disabled_make_offer_on_product_sale'] === 1 && $_product->is_on_sale()) {
+        if (!ofwc_product_allows_offers($_product, $button_options_general)) {
             return $tabs;
         }
 
@@ -1427,6 +1429,19 @@ class Angelleye_Offers_For_Woocommerce {
             $formData['offer_total'] = !empty($post['offer_total']) ? Angelleye_Offers_For_Woocommerce_Admin::ofwc_format_localized_price(wc_clean($post['offer_total'])) : '';
 
             $offer_product = wc_get_product($formData['orig_offer_product_id']);
+            if ($offer_product && !ofwc_product_allows_offers($offer_product)) {
+                if (is_ajax()) {
+                    echo json_encode(array(
+                        "statusmsg" => 'failed-custom',
+                        "statusmsgDetail" => __('Offers are not available for sale products.', 'offers-for-woocommerce')
+                    ));
+                    exit;
+                } else {
+                    $this->set_session('ofwpa_issue', __('Offers are not available for sale products.', 'offers-for-woocommerce'));
+                    return false;
+                }
+            }
+
             if ($offer_product && $offer_product->is_type('variable')) {
                 $offer_variation_id = absint($formData['orig_offer_variation_id']);
                 $offer_variation = $offer_variation_id ? wc_get_product($offer_variation_id) : false;

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -390,12 +390,12 @@ class Angelleye_Offers_For_Woocommerce {
         /**
          * Get offers options - general
          */
-        $button_options_general = get_option('offers_for_woocommerce_options_general');
+        $button_options_general = ofwc_get_general_settings();
 
         /**
          * Get offers options - display
          */
-        $button_options_display = get_option('offers_for_woocommerce_options_display');
+        $button_options_display = ofwc_get_display_settings();
 
         /**
          * Enable offers for only logged-in users
@@ -514,11 +514,11 @@ class Angelleye_Offers_For_Woocommerce {
             return;
         }
 
-        $button_options_display = get_option('offers_for_woocommerce_options_display');
+        $button_options_display = ofwc_get_display_settings();
         $no_price_product_class = ( $_product->get_price() === '' ) ? 'ofwc_no_price_product' : '';
         $button_position = $button_options_display['display_setting_make_offer_button_position_single'];
         $is_on_right = ($button_position == 'right_of_add') ? 'ofwc-button-right-of-add-to-cart' : '';
-        $button_options_display = get_option('offers_for_woocommerce_options_display');
+        $button_options_display = ofwc_get_display_settings();
 
         if ($button_options_display['display_setting_make_offer_button_position_single'] == 'before_add') {
             echo $this->angelleye_ofwc_offer_button_output(false, 'before_add_class');
@@ -541,7 +541,7 @@ class Angelleye_Offers_For_Woocommerce {
             return;
         }
 
-        $button_options_display = get_option('offers_for_woocommerce_options_display');
+        $button_options_display = ofwc_get_display_settings();
 
         if ($button_options_display['display_setting_make_offer_button_position_single'] === 'default' || $button_options_display['display_setting_make_offer_button_position_single'] === 'right_of_add') {
             /* echo '<div class="angelleye-offers-clearfix"></div>'; */
@@ -569,7 +569,7 @@ class Angelleye_Offers_For_Woocommerce {
         }
 
         $hidden_class = '';
-        $button_options_display = get_option('offers_for_woocommerce_options_display');
+        $button_options_display = ofwc_get_display_settings();
 
         if ($button_options_display['display_setting_make_offer_button_position_single'] != 'after_tabs') {
             $hidden_class = 'angelleye-ofwc-hidden';
@@ -591,8 +591,8 @@ class Angelleye_Offers_For_Woocommerce {
      */
     public function angelleye_ofwc_after_show_loop_item($post) {
 
-        /* $button_options_display = get_option('offers_for_woocommerce_options_display'); */
-        $button_options_general = get_option('offers_for_woocommerce_options_general');
+        /* $button_options_display = ofwc_get_display_settings(); */
+        $button_options_general = ofwc_get_general_settings();
         $button_global_onoff_frontpage = ( $button_options_general && isset( $button_options_general['general_setting_enable_make_offer_btn_frontpage'] ) && $button_options_general['general_setting_enable_make_offer_btn_frontpage'] !== '') ? true : false;
         $button_global_onoff_catalog = ( $button_options_general && isset( $button_options_general['general_setting_enable_make_offer_btn_catalog'] ) && $button_options_general['general_setting_enable_make_offer_btn_catalog'] !== '') ? true : false;
 
@@ -618,12 +618,12 @@ class Angelleye_Offers_For_Woocommerce {
         /**
          * Get offers options - general.
          */
-        $button_options_general = get_option('offers_for_woocommerce_options_general');
+        $button_options_general = ofwc_get_general_settings();
 
         /**
          * Get offers options - display.s
          */
-        $button_options_display = get_option('offers_for_woocommerce_options_display');
+        $button_options_display = ofwc_get_display_settings();
 
         /**
          * Enable offers for only logged in users.
@@ -737,12 +737,12 @@ class Angelleye_Offers_For_Woocommerce {
         /**
          * Get offers options - general
          */
-        $button_options_general = get_option('offers_for_woocommerce_options_general');
+        $button_options_general = ofwc_get_general_settings();
 
         /**
          * Get offers options - display
          */
-        $button_options_display = get_option('offers_for_woocommerce_options_display');
+        $button_options_display = ofwc_get_display_settings();
 
         /**
          * Enable offers for only logged in users
@@ -845,7 +845,7 @@ class Angelleye_Offers_For_Woocommerce {
         /**
          * Get offers options - general
          */
-        $button_options_general = get_option('offers_for_woocommerce_options_general');
+        $button_options_general = ofwc_get_general_settings();
         $currency_symbol = get_woocommerce_currency_symbol();
 
         /**
@@ -990,7 +990,7 @@ class Angelleye_Offers_For_Woocommerce {
         /**
          * Get options for button display.
          */
-        $button_display_options = get_option('offers_for_woocommerce_options_display');
+        $button_display_options = ofwc_get_display_settings();
         $button_display_position = get_option('angelleye_displaySettingFormFieldPosition');
 
         $currency_symbol = get_woocommerce_currency_symbol();
@@ -1307,6 +1307,25 @@ class Angelleye_Offers_For_Woocommerce {
     }
 
     /**
+     * Return a standardized offer submission validation failure.
+     *
+     * @param string $message Error message.
+     * @return false|void
+     */
+    private function ofwc_fail_offer_submission($message) {
+        if (is_ajax()) {
+            echo wp_json_encode(array(
+                'statusmsg' => 'failed-custom',
+                'statusmsgDetail' => $message,
+            ));
+            exit;
+        }
+
+        $this->set_session('ofwpa_issue', $message);
+        return false;
+    }
+
+    /**
      * Callback function of wp_ajax_new_offer_form_submit hook.
      *
      * @since 0.1.0
@@ -1407,8 +1426,18 @@ class Angelleye_Offers_For_Woocommerce {
          * Check if form was posted and select task accordingly.
          */
         if (isset($post["offer_product_id"]) && $post["offer_product_id"] !== '') {
+            $button_options_general = ofwc_get_general_settings();
+            $button_display_options = ofwc_get_display_settings();
+            $required_offer_fields = ofwc_get_required_offer_form_fields($button_display_options);
+
+            $current_user_offer_access = ofwc_current_user_can_submit_offers($button_options_general);
+            if (is_wp_error($current_user_offer_access)) {
+                return $this->ofwc_fail_offer_submission($current_user_offer_access->get_error_message());
+            }
 
             $payment_authorization = !empty($post['make_offer_payment_authorization']) ? $post['make_offer_payment_authorization'] : '';
+            $parent_post_id = isset($post['parent_offer_id']) ? absint($post['parent_offer_id']) : 0;
+            $is_counter_offer = $parent_post_id > 0;
 
             /**
              * Set postmeta original vars.
@@ -1429,17 +1458,68 @@ class Angelleye_Offers_For_Woocommerce {
             $formData['offer_total'] = !empty($post['offer_total']) ? Angelleye_Offers_For_Woocommerce_Admin::ofwc_format_localized_price(wc_clean($post['offer_total'])) : '';
 
             $offer_product = wc_get_product($formData['orig_offer_product_id']);
-            if ($offer_product && !ofwc_product_allows_offers($offer_product)) {
-                if (is_ajax()) {
-                    echo json_encode(array(
-                        "statusmsg" => 'failed-custom',
-                        "statusmsgDetail" => __('Offers are not available for sale products.', 'offers-for-woocommerce')
-                    ));
-                    exit;
-                } else {
-                    $this->set_session('ofwpa_issue', __('Offers are not available for sale products.', 'offers-for-woocommerce'));
-                    return false;
+            if (!$offer_product) {
+                return $this->ofwc_fail_offer_submission(__('Error - Product Not Found; See shop manager for assistance', 'offers-for-woocommerce'));
+            }
+
+            if ('yes' !== $offer_product->get_meta('offers_for_woocommerce_enabled', true)) {
+                return $this->ofwc_fail_offer_submission(__('Offers are disabled for this product.', 'offers-for-woocommerce'));
+            }
+
+            if (!ofwc_product_allows_offers($offer_product, $button_options_general)) {
+                return $this->ofwc_fail_offer_submission(__('Offers are not available for sale products.', 'offers-for-woocommerce'));
+            }
+
+            if (!ofwc_is_supported_offer_product_type($offer_product)) {
+                return $this->ofwc_fail_offer_submission(__('Offers are only available for simple and variable products.', 'offers-for-woocommerce'));
+            }
+
+            if ($is_counter_offer) {
+                $parent_offer_name = get_post_meta($parent_post_id, 'offer_name', true);
+                $parent_offer_company_name = get_post_meta($parent_post_id, 'offer_company_name', true);
+                $parent_offer_phone = get_post_meta($parent_post_id, 'offer_phone', true);
+                $parent_offer_email = get_post_meta($parent_post_id, 'offer_email', true);
+
+                if (empty($formData['orig_offer_name']) && !empty($parent_offer_name)) {
+                    $formData['orig_offer_name'] = $parent_offer_name;
                 }
+                if (empty($formData['orig_offer_company_name']) && !empty($parent_offer_company_name)) {
+                    $formData['orig_offer_company_name'] = $parent_offer_company_name;
+                }
+                if (empty($formData['orig_offer_phone']) && !empty($parent_offer_phone)) {
+                    $formData['orig_offer_phone'] = $parent_offer_phone;
+                }
+                if (empty($formData['orig_offer_email']) && !empty($parent_offer_email)) {
+                    $formData['orig_offer_email'] = $parent_offer_email;
+                }
+            }
+
+            if (empty($formData['orig_offer_name'])) {
+                return $this->ofwc_fail_offer_submission(__('Please enter your name.', 'offers-for-woocommerce'));
+            }
+
+            if (empty($formData['orig_offer_email'])) {
+                return $this->ofwc_fail_offer_submission(__('Please enter your email address.', 'offers-for-woocommerce'));
+            }
+
+            if (!is_email($formData['orig_offer_email'])) {
+                return $this->ofwc_fail_offer_submission(__('Please enter a valid email address.', 'offers-for-woocommerce'));
+            }
+
+            if (!empty($required_offer_fields['offer_company_name']) && empty($formData['orig_offer_company_name'])) {
+                return $this->ofwc_fail_offer_submission(__('Please enter your company name.', 'offers-for-woocommerce'));
+            }
+
+            if (!empty($required_offer_fields['offer_phone']) && empty($formData['orig_offer_phone'])) {
+                if (empty($post['offer_phone'])) {
+                    return $this->ofwc_fail_offer_submission(__('Please enter your phone number.', 'offers-for-woocommerce'));
+                }
+
+                return $this->ofwc_fail_offer_submission(__('Please enter a valid phone number.', 'offers-for-woocommerce'));
+            }
+
+            if (!empty($required_offer_fields['offer_notes']) && empty($post['offer_notes'])) {
+                return $this->ofwc_fail_offer_submission(__('Please enter offer notes.', 'offers-for-woocommerce'));
             }
 
             if ($offer_product && $offer_product->is_type('variable')) {
@@ -1452,16 +1532,21 @@ class Angelleye_Offers_For_Woocommerce {
                     || !$offer_variation->is_type('variation')
                     || absint($offer_variation->get_parent_id()) !== absint($formData['orig_offer_product_id'])
                 ) {
-                    if (is_ajax()) {
-                        echo json_encode(array(
-                            "statusmsg" => 'failed-custom',
-                            "statusmsgDetail" => __('Please choose a product variation before submitting your offer.', 'offers-for-woocommerce')
-                        ));
-                        exit;
-                    } else {
-                        $this->set_session('ofwpa_issue', __('Please choose a product variation before submitting your offer.', 'offers-for-woocommerce'));
-                        return false;
-                    }
+                    return $this->ofwc_fail_offer_submission(__('Please choose a product variation before submitting your offer.', 'offers-for-woocommerce'));
+                }
+            }
+
+            $target_offer_product = !empty($offer_variation) ? $offer_variation : $offer_product;
+            $submitted_quantity = absint($formData['orig_offer_quantity']);
+
+            if ($target_offer_product->is_sold_individually() && 1 !== $submitted_quantity) {
+                return $this->ofwc_fail_offer_submission(__('This product must be submitted with a quantity of 1.', 'offers-for-woocommerce'));
+            }
+
+            if (!empty($button_options_general['general_setting_limit_offer_quantity_by_stock']) && !$target_offer_product->backorders_allowed()) {
+                $available_stock_quantity = ofwc_get_product_stock_quantity($target_offer_product);
+                if (null !== $available_stock_quantity && '' !== $available_stock_quantity && $submitted_quantity > (int) $available_stock_quantity) {
+                    return $this->ofwc_fail_offer_submission(__('The offer quantity exceeds the available stock.', 'offers-for-woocommerce'));
                 }
             }
 
@@ -1471,18 +1556,15 @@ class Angelleye_Offers_For_Woocommerce {
                     if (isset($post['g-recaptcha-response']) && !empty($post['g-recaptcha-response'])) {
                         $response = $this->recaptcha_verify_response($post['g-recaptcha-response']);
                         if (empty($response)) {
-                            echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Please check the captcha.', 'offers-for-woocommerce')));
-                            exit;
+                            return $this->ofwc_fail_offer_submission(__('Please check the captcha.', 'offers-for-woocommerce'));
                         } else {
                             $response_array = json_decode($response, true);
                             if ($response_array['success'] !== true) {
-                                echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Please check the captcha.', 'offers-for-woocommerce')));
-                                exit;
+                                return $this->ofwc_fail_offer_submission(__('Please check the captcha.', 'offers-for-woocommerce'));
                             }
                         }
                     } else {
-                        echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Please check the captcha.', 'offers-for-woocommerce')));
-                        exit;
+                        return $this->ofwc_fail_offer_submission(__('Please check the captcha.', 'offers-for-woocommerce'));
                     }
                 } else {
                     if (isset($post['ofw_google']) && !empty($post['ofw_google'])) {
@@ -1491,21 +1573,20 @@ class Angelleye_Offers_For_Woocommerce {
                             'body' => array('secret' => $ofw_recaptcha_secret_key_v3, 'response' => $post['ofw_google'])
                         ));
                         if (is_wp_error($response_data)) {
-                            echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Google recaptcha verification Failed.', 'offers-for-woocommerce')));
-                            exit;
+                            return $this->ofwc_fail_offer_submission(__('Google recaptcha verification Failed.', 'offers-for-woocommerce'));
                         }
                         $body = wp_remote_retrieve_body($response_data);
                         if (!empty($body)) {
                             $response = json_decode($body);
                             if (!$response->success) {
-                                echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Google recaptcha verification Failed.', 'offers-for-woocommerce')));
-                                exit;
+                                return $this->ofwc_fail_offer_submission(__('Google recaptcha verification Failed.', 'offers-for-woocommerce'));
                             }
                             if ($response->score < 0.2) {
-                                echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Very likely a bot.', 'offers-for-woocommerce')));
-                                exit;
+                                return $this->ofwc_fail_offer_submission(__('Very likely a bot.', 'offers-for-woocommerce'));
                             }
                         }
+                    } else {
+                        return $this->ofwc_fail_offer_submission(__('Please check the captcha.', 'offers-for-woocommerce'));
                     }
                 }
             }
@@ -1515,25 +1596,14 @@ class Angelleye_Offers_For_Woocommerce {
              * check for valid offer quantity (not zero)
              */
             if (($formData['orig_offer_quantity'] === '' || $formData['orig_offer_quantity'] === 0)) {
-                if (is_ajax()) {
-                    echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Please enter a positive value for \'Offer Quantity\'', 'offers-for-woocommerce')));
-                    exit;
-                } else {
-                    return false;
-                }
+                return $this->ofwc_fail_offer_submission(__('Please enter a positive value for \'Offer Quantity\'', 'offers-for-woocommerce'));
             }
 
             /**
              * check for valid offer price (not zero).
              */
             if (($formData['orig_offer_price_per'] === '' || $formData['orig_offer_price_per'] === 0 || $formData['orig_offer_price_per'] === "0.00")) {
-                if (is_ajax()) {
-                    echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Please enter a positive value for \'Offer Amount\'', 'offers-for-woocommerce')));
-                    exit;
-                } else {
-                    $this->set_session('ofwpa_issue', 'Please enter a positive value for Offer Amount');
-                    return false;
-                }
+                return $this->ofwc_fail_offer_submission(__('Please enter a positive value for \'Offer Amount\'', 'offers-for-woocommerce'));
             }
 
             /**
@@ -1544,12 +1614,9 @@ class Angelleye_Offers_For_Woocommerce {
                 $return = $this->ofwc_minimum_offer($formData['orig_offer_product_id'], $formData['offer_product_price'], $formData['offer_total'], $formData['orig_offer_quantity']);
                 $symbol = get_woocommerce_currency_symbol();
                 if (is_array($return) && $return['status'] === 'failed' && $return['type'] === 'price') {
-                    echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Minimum Offer price is ' . $symbol . $return['minimum_offer_price'], 'offers-for-woocommerce')));
-                    exit;
+                    return $this->ofwc_fail_offer_submission(__('Minimum Offer price is ' . $symbol . $return['minimum_offer_price'], 'offers-for-woocommerce'));
                 } elseif (is_array($return) && $return['status'] === 'failed' && $return['type'] === 'percentage') {
-                    echo json_encode(array("statusmsg" => 'failed-custom',
-                        "statusmsgDetail" => __('Minimum Offer price must be ' . $return['percent'] . '%. For ' . $return['qty'] . ' quantity Minimum offer price is ' . wc_price($return['minimum_offer_price']), 'offers-for-woocommerce')));
-                    exit;
+                    return $this->ofwc_fail_offer_submission(__('Minimum Offer price must be ' . $return['percent'] . '%. For ' . $return['qty'] . ' quantity Minimum offer price is ' . wc_price($return['minimum_offer_price']), 'offers-for-woocommerce'));
                 }
             } else {
                 //echo "in else odder condition";
@@ -1652,14 +1719,10 @@ class Angelleye_Offers_For_Woocommerce {
                 if ((isset($parent_post_status) && $parent_post_status !== 'countered-offer') || ($post_parent_type !== 'woocommerce_offer') || ($parent_post_offer_uid !== $formData['parent_offer_uid'])) {
                     $offer = get_post($parent_post_id);
                     if (apply_filters('ofw_not_allow_invalid_offer_status', false, $offer)) {
-                        if (is_ajax()) {
-                            echo json_encode(array("statusmsg" => 'failed-custom', "statusmsgDetail" => __('Invalid Parent Offer Id; See shop manager for assistance', 'offers-for-woocommerce')));
-                            exit;
-                        } else {
-                            $this->set_session('ofwpa_issue', 'Invalid Parent Offer Id; See shop manager for assistance');
-                            return false;
-                        }
+                        return $this->ofwc_fail_offer_submission(__('Invalid Parent Offer Id; See shop manager for assistance', 'offers-for-woocommerce'));
                     }
+
+                    return $this->ofwc_fail_offer_submission(__('Invalid Parent Offer Id; See shop manager for assistance', 'offers-for-woocommerce'));
                 }
 
                 $parent_post = array(
@@ -1888,7 +1951,7 @@ class Angelleye_Offers_For_Woocommerce {
              * Below code is work for Disabled email notification for admin user when offers is auto decline for product
              * Setting ->  General -> Disable Admin Email on Auto Decline Offer
              */
-            $button_options_general = get_option('offers_for_woocommerce_options_general');
+            $button_options_general = ofwc_get_general_settings();
 	        $option_for_admin_disable_email_auto_decline = isset($button_options_general['general_setting_admin_disable_email_auto_decline']) ? $button_options_general['general_setting_admin_disable_email_auto_decline'] : '';
             $offer_is_auto_decline = '';
             if ($option_for_admin_disable_email_auto_decline == '1') {
@@ -3032,7 +3095,7 @@ class Angelleye_Offers_For_Woocommerce {
             return $boolean;
         }
 
-        $button_options_general = get_option('offers_for_woocommerce_options_general');
+        $button_options_general = ofwc_get_general_settings();
         if (!is_admin() && !empty(WC()->cart) && !WC()->cart->is_empty() && (isset($button_options_general['general_setting_disable_coupon']) && $button_options_general['general_setting_disable_coupon'] != '')) {
             foreach (WC()->cart->get_cart() as $cart_item_key => $values) {
                 if (isset($values['woocommerce_offer_id']) && !empty($values['woocommerce_offer_id'])) {
@@ -3066,7 +3129,7 @@ class Angelleye_Offers_For_Woocommerce {
      * @return bool
      */
     public function ofw_is_anonymous_communication_enable() {
-        $offers_for_woocommerce_options_general = get_option('offers_for_woocommerce_options_general');
+        $offers_for_woocommerce_options_general = ofwc_get_general_settings();
         if (isset($offers_for_woocommerce_options_general['general_setting_enable_anonymous_communication']) && $offers_for_woocommerce_options_general['general_setting_enable_anonymous_communication'] == 1) {
             return true;
         }
@@ -3171,7 +3234,7 @@ class Angelleye_Offers_For_Woocommerce {
      * @return bool
      */
     public function ofw_is_show_pending_offer_enable() {
-        $offers_for_woocommerce_options_general = get_option('offers_for_woocommerce_options_general');
+        $offers_for_woocommerce_options_general = ofwc_get_general_settings();
         if (isset($offers_for_woocommerce_options_general['general_setting_show_pending_offer']) && $offers_for_woocommerce_options_general['general_setting_show_pending_offer'] == 1) {
             return true;
         }
@@ -3311,7 +3374,7 @@ class Angelleye_Offers_For_Woocommerce {
      * @return bool
      */
     public function ofw_is_highest_current_bid_enable() {
-        $offers_for_woocommerce_options_general = get_option('offers_for_woocommerce_options_general');
+        $offers_for_woocommerce_options_general = ofwc_get_general_settings();
         if (isset($offers_for_woocommerce_options_general['general_setting_show_highest_current_bid']) && $offers_for_woocommerce_options_general['general_setting_show_highest_current_bid'] === 1) {
             return true;
         }
@@ -3328,7 +3391,7 @@ class Angelleye_Offers_For_Woocommerce {
      * @return mixed
      */
     public function ofwc_body_class($classes) {
-        $offers_for_woocommerce_options_general = get_option('offers_for_woocommerce_options_general');
+        $offers_for_woocommerce_options_general = ofwc_get_general_settings();
         if (isset($offers_for_woocommerce_options_general['general_setting_enable_make_offer_btn_catalog']) && $offers_for_woocommerce_options_general['general_setting_enable_make_offer_btn_catalog'] === 1 && is_shop()) {
             $classes[] = 'ofwc-shop-page';
         }
@@ -3750,7 +3813,7 @@ class Angelleye_Offers_For_Woocommerce {
      * @return false|mixed
      */
     public function angelleye_ofw_remove_discount_calculation($boolean) {
-        $button_options_general = get_option('offers_for_woocommerce_options_general');
+        $button_options_general = ofwc_get_general_settings();
 
         if (!is_admin() && !empty(WC()->cart) && !WC()->cart->is_empty() && (isset($button_options_general['general_setting_disable_coupon']) && $button_options_general['general_setting_disable_coupon'] != '')) {
             foreach (WC()->cart->get_cart() as $cart_item_key => $values) {

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -441,6 +441,7 @@ class Angelleye_Offers_For_Woocommerce {
         }
 
         $is_instock = $_product->is_in_stock();
+        $is_onsale = $_product->is_on_sale();
 
         $custom_tab_options_offers = array(
             'enabled' => get_post_meta($post->ID, 'offers_for_woocommerce_enabled', true),
@@ -454,7 +455,7 @@ class Angelleye_Offers_For_Woocommerce {
             $is_display_offer_button = false;
         }
 
-        if ($custom_tab_options_offers['enabled'] == 'yes' && $is_display_offer_button && $is_instock && $custom_tab_options_offers['on_exit'] != 'yes') {
+        if ($custom_tab_options_offers['enabled'] == 'yes' && $is_display_offer_button && $is_instock && !$is_onsale && $custom_tab_options_offers['on_exit'] != 'yes') {
 
             $button_title = (isset($button_options_display['display_setting_custom_make_offer_btn_text']) && $button_options_display['display_setting_custom_make_offer_btn_text'] != '') ? __($button_options_display['display_setting_custom_make_offer_btn_text'], 'offers-for-woocommerce') : __('Make Offer', 'offers-for-woocommerce');
             $button_title = apply_filters('aeofwc_make_offer_button_label', $button_title);

--- a/public/views/my-offers.php
+++ b/public/views/my-offers.php
@@ -71,14 +71,8 @@ if ($customer_offers) :
                                         break;
                                     case 'offer_product_title' :                                  
                                         if ($product_title) {
-                                            if(version_compare(WC_VERSION, '3.0', '<')){
-                                                $product_type = $product->product_type;
-                                                $pproduct_id  = $product->id;
-                                            } 
-                                            else{
-                                                $product_type = $product->get_type();
-                                                $pproduct_id  = $product->get_id();
-                                            }
+                                            $product_type = method_exists( $product, 'get_type' ) ? $product->get_type() : ( isset( $product->product_type ) ? $product->product_type : '' );
+                                            $pproduct_id  = method_exists( $product, 'get_id' ) ? $product->get_id() : ( isset( $product->id ) ? $product->id : 0 );
                                             if ($product_type == 'variation') {
                                                 $_product = new WC_Product_Variation($variant_id);
                                                 if(get_post_status($pproduct_id) == 'trash'){

--- a/public/views/public.php
+++ b/public/views/public.php
@@ -65,14 +65,8 @@ if( !empty( $offer_single_use ) ) {
         <fieldset>
             <div class="make-offer-form-intro">
                 <?php
-                if(version_compare(WC_VERSION, '3.0', '<')){
-                    $product = get_product( $post->ID );
-                    $product_id = $product->id;
-                }
-                else{
-                    $product = wc_get_product( $post->ID );
-                    $product_id = $product->get_id();
-                }
+                $product = wc_get_product( $post->ID );
+                $product_id = $product && method_exists( $product, 'get_id' ) ? $product->get_id() : ( isset( $product->id ) ? $product->id : 0 );
                 /* Get Product type */
                 if( $product->is_type( 'variable' ) ){
                     $product_type = 'variable';


### PR DESCRIPTION

## Summary
Audit `new_offer_form_submit()` and add server-side enforcement for the settings that currently only gate UI rendering. Today submission is only partially aligned: it already enforces sale-item blocking, variation selection, minimum offer rules, counter-offer validity, and reCAPTCHA v2, but it does not consistently enforce login/role/product eligibility/form-required settings, and reCAPTCHA v3 can be bypassed when the token is missing.

## Key Changes
- Add one shared submission-policy helper layer in the common helper file to answer:
  - whether offers are allowed for the current user and product
  - whether the submitted product type is eligible for offers
  - which form fields are required by display settings
- Call that policy layer at the top of `new_offer_form_submit()` before any offer post is created.

- Enforce these settings server-side in submission:
  - `general_setting_enable_offers_only_logged_in_users`: reject submission from logged-out users.
  - `general_setting_allowed_roles`: reject logged-in users whose role is not allowed.
  - product-level `offers_for_woocommerce_enabled`: reject submission if offers are disabled on the target product.
  - sale-product rule via the existing shared helper: keep current backend enforcement.
  - eligible product types: only allow `simple` and `variable`, matching the UI.
  - variable products: keep the current variation-parent validation.
  - `general_setting_limit_offer_quantity_by_stock`: reject submitted quantity above available stock when backorders are not allowed.
  - sold-individually products: require quantity `1`.
  - display field required settings:
    - always require `offer_name`
    - always require `offer_email`
    - require `offer_company_name` only when its field is enabled and marked required
    - require `offer_phone` only when its field is enabled and marked required
    - require `offer_notes` only when its field is enabled and marked required
  - email validity: validate `offer_email` with `is_email()`.
  - phone validity: keep current normalization, but if phone is marked required and normalization fails, reject.
  - reCAPTCHA v3: reject when `ofw_google` is missing, not only when present and invalid.

- Keep these settings as render-only and do not force them into submission validation:
  - button position / text / color / lightbox presentation
  - frontpage/catalog display toggles
  - anonymous communication
  - show pending offer / show highest offer
  - disable coupons
  - auto-accept / auto-decline percentages
  - on-exit-only display mode
  These affect presentation or later workflow, not whether a submission is valid.

- Standardize failure responses:
  - use the existing `failed-custom` JSON shape for AJAX
  - use `set_session( 'ofwpa_issue', ... )` for non-AJAX
  - add explicit messages for each rejected policy:
    - login required
    - role not allowed
    - offers disabled for product
    - unsupported product type
    - quantity exceeds available stock
    - sold individually must be quantity 1
    - required field missing
    - invalid email
    - invalid phone
    - missing reCAPTCHA token

## Test Plan
- User gating
  - logged-out user submits when login is required: rejected
  - logged-in user with disallowed role submits: rejected
  - allowed user submits: accepted
- Product gating
  - product with `offers_for_woocommerce_enabled = no`: rejected
  - sale product with sale blocking enabled: rejected
  - sale product with sale blocking disabled: accepted
  - grouped/external product direct POST: rejected
  - variable product without valid variation: rejected
- Quantity and stock
  - sold-individually product with quantity > 1: rejected
  - stock-limited product with submitted quantity above stock and no backorders: rejected
  - same product with setting off: accepted
- Form field rules
  - missing name/email: rejected
  - required company/phone/notes missing: rejected
  - optional company/phone/notes omitted: accepted
  - invalid email: rejected
  - invalid required phone: rejected
- CAPTCHA
  - v2 enabled and token missing/invalid: rejected
  - v3 enabled and token missing: rejected
  - v3 enabled and score too low: rejected
- Regression
  - minimum offer amount/percentage still enforced
  - counter-offer parent validation still enforced
  - successful valid offer still creates the offer and existing post/comment side effects

## Assumptions
- “Inline with settings” means server-side submission must enforce any setting that determines whether a user may submit an offer or what data is required, not purely visual presentation settings.
- Required field behavior should follow the current form builder: name/email are always required; company/phone/notes are only required when their field is enabled and marked required.
- Product eligibility for actual offer submission should match the existing frontend affordance: `simple` and `variable` only.
