### PR TITLE
feat: Add multi-currency compatibility for VillaTheme WooCommerce Multi Currency plugin

### DIFF
--- a/admin/views/meta-panel-summary.php
+++ b/admin/views/meta-panel-summary.php
@@ -231,9 +231,9 @@
                         <div class="angelleye-input-group">
                             <span class="angelleye-input-group-addon"><?php echo (isset($currency_symbol)) ? $currency_symbol : '$';?></span>
                             <?php if( isset( $current_status_value ) && $current_status_value == 'buyercountered-offer' ) { ?>
-                                <input type="text" name="offer_price_per" id="offer-price-per" pattern="([0-9]|\$|,|.)+" data-a-sign="" data-m-dec="2" data-w-empty="" data-l-zero="keep" data-a-form="false" required="required" value="<?php echo (isset($postmeta['offer_buyer_counter_price_per'][0])) ? number_format($postmeta['offer_buyer_counter_price_per'][0],wc_get_price_decimals(),wc_get_price_decimal_separator(),wc_get_price_thousand_separator())  : ''; ?>" autocomplete="off" />
+                                <input type="text" name="offer_price_per" id="offer-price-per" pattern="([0-9]|\$|,|.)+" data-a-sign="" data-m-dec="2" data-w-empty="" data-l-zero="keep" data-a-form="false" required="required" value="<?php echo (isset($postmeta['offer_buyer_counter_price_per'][0])) ? esc_attr($postmeta['offer_buyer_counter_price_per'][0]) : ''; ?>" autocomplete="off" />
                             <?php } else { ?>
-                                <input type="text" name="offer_price_per" id="offer-price-per" pattern="([0-9]|\$|,|.)+" data-a-sign="" data-m-dec="2" data-w-empty="" data-l-zero="keep" data-a-form="false" required="required" value="<?php echo (isset($postmeta['offer_price_per'][0])) ? number_format($postmeta['offer_price_per'][0],wc_get_price_decimals(),wc_get_price_decimal_separator(),wc_get_price_thousand_separator()) : ''; ?>" autocomplete="off" />
+                                <input type="text" name="offer_price_per" id="offer-price-per" pattern="([0-9]|\$|,|.)+" data-a-sign="" data-m-dec="2" data-w-empty="" data-l-zero="keep" data-a-form="false" required="required" value="<?php echo (isset($postmeta['offer_price_per'][0])) ? esc_attr($postmeta['offer_price_per'][0]) : ''; ?>" autocomplete="off" />
                             <?php } ?>
                         </div>
                         <div style="display: none" id="counter_offer_notice" class="note_content">
@@ -243,16 +243,16 @@
                         <div class="angelleye-input-group offer_shipping">
                             <span class="angelleye-input-group-addon"><?php echo (isset($currency_symbol)) ? $currency_symbol : '$';?></span>
                             <label for="offer_shipping_cost"></label>
-                            <input type="text" name="offer_shipping_cost" id="offer_shipping_cost" pattern="([0-9]|\$|,|.)+" data-a-sign="" data-m-dec="2" data-w-empty="" data-l-zero="keep" data-a-form="false" value="<?php echo (isset($postmeta['offer_shipping_cost'][0])) ? number_format($postmeta['offer_shipping_cost'][0],wc_get_price_decimals(),wc_get_price_decimal_separator(),wc_get_price_thousand_separator()) : ''; ?>" autocomplete="off" />
+                            <input type="text" name="offer_shipping_cost" id="offer_shipping_cost" pattern="([0-9]|\$|,|.)+" data-a-sign="" data-m-dec="2" data-w-empty="" data-l-zero="keep" data-a-form="false" value="<?php echo (isset($postmeta['offer_shipping_cost'][0])) ? esc_attr($postmeta['offer_shipping_cost'][0]) : ''; ?>" autocomplete="off" />
                         </div>
 
                         <label for="offer-total"><?php echo __('Total', 'offers-for-woocommerce'); ?></label>
                         <div class="angelleye-input-group">
                             <span class="angelleye-input-group-addon"><?php echo (isset($currency_symbol)) ? $currency_symbol : '$';?></span>
                             <?php if( isset( $current_status_value ) && $current_status_value == 'buyercountered-offer' ) { ?>
-                                <input type="text" name="offer_amount" id="offer-total" class="form-control" data-currency-symbol="<?php echo (isset($currency_symbol)) ? $currency_symbol : '$';?>" value="<?php echo (isset($postmeta['offer_buyer_counter_amount'][0])) ? number_format($postmeta['offer_buyer_counter_amount'][0],wc_get_price_decimals(),wc_get_price_decimal_separator(),wc_get_price_thousand_separator()) : ''; ?>" disabled="disabled" autocomplete="off" />
+                                <input type="text" name="offer_amount" id="offer-total" class="form-control" data-currency-symbol="<?php echo (isset($currency_symbol)) ? $currency_symbol : '$';?>" value="<?php echo (isset($postmeta['offer_buyer_counter_amount'][0])) ? esc_attr($postmeta['offer_buyer_counter_amount'][0]) : ''; ?>" disabled="disabled" autocomplete="off" />
                             <?php } else { ?>
-                                <input type="text" name="offer_amount" id="offer-total" class="form-control" data-currency-symbol="<?php echo (isset($currency_symbol)) ? $currency_symbol : '$';?>" value="<?php echo (isset($postmeta['offer_amount'][0])) ? number_format($postmeta['offer_amount'][0],wc_get_price_decimals(),wc_get_price_decimal_separator(),wc_get_price_thousand_separator()) : ''; ?>" disabled="disabled" autocomplete="off" />
+                                <input type="text" name="offer_amount" id="offer-total" class="form-control" data-currency-symbol="<?php echo (isset($currency_symbol)) ? $currency_symbol : '$';?>" value="<?php echo (isset($postmeta['offer_amount'][0])) ? esc_attr($postmeta['offer_amount'][0]) : ''; ?>" disabled="disabled" autocomplete="off" />
                             <?php } ?>
                         </div>
                     </div>

--- a/includes/angelleye-offers-for-woocommerce-function.php
+++ b/includes/angelleye-offers-for-woocommerce-function.php
@@ -270,24 +270,33 @@ if (!function_exists('angelleye_ofw_get_product_price_multi_currency')) {
      * @return mixed
      */
     function angelleye_ofw_get_product_price_multi_currency($price, $currency) {
+        if (empty($price) || empty($currency)) {
+            return $price;
+        }
+
+        $converted = apply_filters('angelleye_ofw_convert_product_price', null, $price, $currency);
+        if ($converted !== null) {
+            return $converted;
+        }
+
         if (class_exists('WC_Aelia_CurrencyPrices_Manager')) {
-            $aelia_manager = new WC_Aelia_CurrencyPrices_Manager();
             $woocommerce_currency = get_woocommerce_currency();
-            if(empty($woocommerce_currency)) {
-                return $price;
-            }
-            if(empty($currency)) {
+            if (empty($woocommerce_currency)) {
                 return $price;
             }
             try {
-                $converted_price = $aelia_manager->convert_from_base($price, $currency, $woocommerce_currency);
+                $aelia_manager = new WC_Aelia_CurrencyPrices_Manager();
+                return $aelia_manager->convert_from_base($price, $currency, $woocommerce_currency);
             } catch (Exception $ex) {
                 return $price;
             }
-            return $converted_price;
-        } else {
-            return $price;
         }
+
+        if (function_exists('wmc_get_price')) {
+            return wmc_get_price($price, $currency);
+        }
+
+        return $price;
     }
 
 }

--- a/includes/angelleye-offers-for-woocommerce-function.php
+++ b/includes/angelleye-offers-for-woocommerce-function.php
@@ -273,30 +273,8 @@ if (!function_exists('angelleye_ofw_get_product_price_multi_currency')) {
         if (empty($price) || empty($currency)) {
             return $price;
         }
-
         $converted = apply_filters('angelleye_ofw_convert_product_price', null, $price, $currency);
-        if ($converted !== null) {
-            return $converted;
-        }
-
-        if (class_exists('WC_Aelia_CurrencyPrices_Manager')) {
-            $woocommerce_currency = get_woocommerce_currency();
-            if (empty($woocommerce_currency)) {
-                return $price;
-            }
-            try {
-                $aelia_manager = new WC_Aelia_CurrencyPrices_Manager();
-                return $aelia_manager->convert_from_base($price, $currency, $woocommerce_currency);
-            } catch (Exception $ex) {
-                return $price;
-            }
-        }
-
-        if (function_exists('wmc_get_price')) {
-            return wmc_get_price($price, $currency);
-        }
-
-        return $price;
+        return ($converted !== null) ? $converted : $price;
     }
 
 }

--- a/includes/compatibility/abstract-class-ofw-compatibility.php
+++ b/includes/compatibility/abstract-class-ofw-compatibility.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Base class for third-party plugin compatibility modules.
+ *
+ * @package offers-for-woocommerce/includes/compatibility
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('OFW_Compatibility')) {
+
+    abstract class OFW_Compatibility {
+
+        /**
+         * Return true when the target third-party plugin is installed and active.
+         *
+         * @return bool
+         */
+        abstract public static function is_active();
+
+        /**
+         * Register WordPress / WooCommerce hooks that integrate with the target plugin.
+         *
+         * @return void
+         */
+        abstract public function register_hooks();
+    }
+}

--- a/includes/compatibility/class-ofw-compatibility-aelia.php
+++ b/includes/compatibility/class-ofw-compatibility-aelia.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Aelia Currency Switcher compatibility.
+ *
+ * @package offers-for-woocommerce/includes/compatibility
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('OFW_Compatibility_Aelia')) {
+
+    class OFW_Compatibility_Aelia extends OFW_Compatibility {
+
+        private $is_notice_set = false;
+
+        public static function is_active() {
+            return class_exists('WC_Aelia_CurrencyPrices_Manager');
+        }
+
+        public function register_hooks() {
+            add_filter('angelleye_ofw_convert_product_price', array($this, 'convert_product_price'), 10, 3);
+            add_filter('wc_aelia_cs_selected_currency', array($this, 'filter_selected_currency'), 99, 1);
+            add_action('wp_loaded', array($this, 'sync_currency_cookie'), 10);
+        }
+
+        public function convert_product_price($converted, $price, $currency) {
+            if ($converted !== null) {
+                return $converted;
+            }
+            $base = get_woocommerce_currency();
+            if (empty($base)) {
+                return $price;
+            }
+            try {
+                $aelia_manager = new WC_Aelia_CurrencyPrices_Manager();
+                return $aelia_manager->convert_from_base($price, $currency, $base);
+            } catch (Exception $e) {
+                return $price;
+            }
+        }
+
+        public function filter_selected_currency($aelia_currency) {
+            if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
+                return $aelia_currency;
+            }
+            foreach (WC()->cart->get_cart() as $cart_item) {
+                if (empty($cart_item['woocommerce_offer_id'])) {
+                    continue;
+                }
+                $offer_currency = get_post_meta($cart_item['woocommerce_offer_id'], 'offer_currency', true);
+                if (empty($offer_currency)) {
+                    continue;
+                }
+                if ($aelia_currency !== $offer_currency && $this->is_notice_set === false) {
+                    $this->is_notice_set = true;
+                    wc_clear_notices();
+                    $message = apply_filters(
+                        'ofw_aelia_notice',
+                        sprintf(__('Aelia Currency Switcher is temporarily disabled as the cart contains an offer product linked to %s currency.', 'offers-for-woocommerce'), $offer_currency),
+                        $offer_currency
+                    );
+                    wc_add_notice($message, 'notice');
+                }
+                $user_id = get_current_user_id();
+                if (!empty($user_id)) {
+                    update_user_meta($user_id, 'aelia_cs_selected_currency', $offer_currency);
+                }
+                return $offer_currency;
+            }
+            return $aelia_currency;
+        }
+
+        public function sync_currency_cookie() {
+            if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
+                return;
+            }
+            foreach (WC()->cart->get_cart() as $cart_item) {
+                if (empty($cart_item['woocommerce_offer_id'])) {
+                    continue;
+                }
+                $offer_currency = get_post_meta($cart_item['woocommerce_offer_id'], 'offer_currency', true);
+                if (empty($offer_currency)) {
+                    continue;
+                }
+                $_POST['aelia_cs_currency'] = $offer_currency;
+                $user_id = get_current_user_id();
+                if (!empty($user_id)) {
+                    update_user_meta($user_id, 'aelia_cs_selected_currency', $offer_currency);
+                    wc_setcookie('aelia_cs_selected_currency', $offer_currency);
+                }
+            }
+        }
+    }
+}

--- a/includes/compatibility/class-ofw-compatibility-loader.php
+++ b/includes/compatibility/class-ofw-compatibility-loader.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Loader for third-party plugin compatibility modules.
+ *
+ * To add a new compatibility module:
+ *   1. Create includes/compatibility/class-ofw-compatibility-{slug}.php
+ *   2. Define a class OFW_Compatibility_{Slug} extending OFW_Compatibility.
+ *   3. Add its class name to self::$classes below.
+ *
+ * @package offers-for-woocommerce/includes/compatibility
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('OFW_Compatibility_Loader')) {
+
+    class OFW_Compatibility_Loader {
+
+        private static $classes = array(
+            'OFW_Compatibility_Aelia',
+            'OFW_Compatibility_Villatheme',
+        );
+
+        public static function load() {
+            require_once __DIR__ . '/abstract-class-ofw-compatibility.php';
+
+            $classes = apply_filters('angelleye_ofw_compatibility_classes', self::$classes);
+
+            foreach ($classes as $class) {
+                $file = __DIR__ . '/' . self::class_to_filename($class);
+                if (file_exists($file)) {
+                    require_once $file;
+                }
+                if (class_exists($class) && is_subclass_of($class, 'OFW_Compatibility') && $class::is_active()) {
+                    $instance = new $class();
+                    $instance->register_hooks();
+                }
+            }
+        }
+
+        private static function class_to_filename($class) {
+            return 'class-' . str_replace('_', '-', strtolower($class)) . '.php';
+        }
+    }
+}

--- a/includes/compatibility/class-ofw-compatibility-villatheme.php
+++ b/includes/compatibility/class-ofw-compatibility-villatheme.php
@@ -27,7 +27,19 @@ if (!class_exists('OFW_Compatibility_Villatheme')) {
             if ($converted !== null) {
                 return $converted;
             }
-            return wmc_get_price($price, $currency);
+            if (!class_exists('WOOMULTI_CURRENCY_Data')) {
+                return $price;
+            }
+            $settings = WOOMULTI_CURRENCY_Data::get_ins();
+            $currencies = $settings->get_list_currencies();
+            if (empty($currencies[$currency]['rate'])) {
+                return $price;
+            }
+            $rate = (float) $currencies[$currency]['rate'];
+            if ($rate <= 0 || $rate == 1.0) {
+                return $price;
+            }
+            return (float) $price * $rate;
         }
 
         public function force_offer_currency($current_currency) {

--- a/includes/compatibility/class-ofw-compatibility-villatheme.php
+++ b/includes/compatibility/class-ofw-compatibility-villatheme.php
@@ -20,7 +20,7 @@ if (!class_exists('OFW_Compatibility_Villatheme')) {
         public function register_hooks() {
             add_filter('angelleye_ofw_convert_product_price', array($this, 'convert_product_price'), 10, 3);
             add_filter('wmc_get_current_currency', array($this, 'force_offer_currency'), 99, 1);
-            add_filter('wmc_is_change_price', array($this, 'skip_conversion_for_offer_items'), 99, 3);
+            add_filter('wmc_product_get_price_condition', array($this, 'skip_conversion_for_offer_products'), 99, 3);
         }
 
         public function convert_product_price($converted, $price, $currency) {
@@ -35,11 +35,24 @@ if (!class_exists('OFW_Compatibility_Villatheme')) {
             if (empty($currencies[$currency]['rate'])) {
                 return $price;
             }
-            $rate = (float) $currencies[$currency]['rate'];
-            if ($rate <= 0 || $rate == 1.0) {
+            $target_rate = (float) $currencies[$currency]['rate'];
+            if ($target_rate <= 0) {
                 return $price;
             }
-            return (float) $price * $rate;
+
+            $vt_skipped = (bool) apply_filters('wmc_get_price_condition', is_admin() && !wp_doing_ajax());
+            if ($vt_skipped) {
+                $base_price = (float) $price;
+            } else {
+                $current = $settings->get_current_currency();
+                $current_rate = !empty($currencies[$current]['rate']) ? (float) $currencies[$current]['rate'] : 1.0;
+                if ($current_rate <= 0) {
+                    return $price;
+                }
+                $base_price = (float) $price / $current_rate;
+            }
+
+            return $base_price * $target_rate;
         }
 
         public function force_offer_currency($current_currency) {
@@ -60,16 +73,32 @@ if (!class_exists('OFW_Compatibility_Villatheme')) {
             return $current_currency;
         }
 
-        public function skip_conversion_for_offer_items($is_change_price, $price = null, $currency = null) {
-            if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
-                return $is_change_price;
+        public function skip_conversion_for_offer_products($condition, $price, $product) {
+            if (!$condition) {
+                return $condition;
             }
+            if (!is_object($product) || !method_exists($product, 'get_id')) {
+                return $condition;
+            }
+            if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
+                return $condition;
+            }
+            $product_id = $product->get_id();
             foreach (WC()->cart->get_cart() as $cart_item) {
-                if (!empty($cart_item['woocommerce_offer_id'])) {
+                if (empty($cart_item['woocommerce_offer_id']) || empty($cart_item['woocommerce_offer_price_per'])) {
+                    continue;
+                }
+                $offer_product_id = !empty($cart_item['variation_id'])
+                    ? (int) $cart_item['variation_id']
+                    : (int) $cart_item['product_id'];
+                if ($offer_product_id !== (int) $product_id) {
+                    continue;
+                }
+                if (abs((float) $price - (float) $cart_item['woocommerce_offer_price_per']) < 0.0001) {
                     return false;
                 }
             }
-            return $is_change_price;
+            return $condition;
         }
     }
 }

--- a/includes/compatibility/class-ofw-compatibility-villatheme.php
+++ b/includes/compatibility/class-ofw-compatibility-villatheme.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * VillaTheme WooCommerce Multi Currency compatibility.
+ *
+ * @package offers-for-woocommerce/includes/compatibility
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('OFW_Compatibility_Villatheme')) {
+
+    class OFW_Compatibility_Villatheme extends OFW_Compatibility {
+
+        public static function is_active() {
+            return function_exists('wmc_get_price');
+        }
+
+        public function register_hooks() {
+            add_filter('angelleye_ofw_convert_product_price', array($this, 'convert_product_price'), 10, 3);
+            add_filter('wmc_get_current_currency', array($this, 'force_offer_currency'), 99, 1);
+            add_filter('wmc_is_change_price', array($this, 'skip_conversion_for_offer_items'), 99, 3);
+        }
+
+        public function convert_product_price($converted, $price, $currency) {
+            if ($converted !== null) {
+                return $converted;
+            }
+            return wmc_get_price($price, $currency);
+        }
+
+        public function force_offer_currency($current_currency) {
+            if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
+                return $current_currency;
+            }
+            foreach (WC()->cart->get_cart() as $cart_item) {
+                if (empty($cart_item['woocommerce_offer_id'])) {
+                    continue;
+                }
+                $offer_currency = !empty($cart_item['woocommerce_offer_currency'])
+                    ? $cart_item['woocommerce_offer_currency']
+                    : get_post_meta($cart_item['woocommerce_offer_id'], 'offer_currency', true);
+                if (!empty($offer_currency)) {
+                    return $offer_currency;
+                }
+            }
+            return $current_currency;
+        }
+
+        public function skip_conversion_for_offer_items($is_change_price, $price = null, $currency = null) {
+            if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
+                return $is_change_price;
+            }
+            foreach (WC()->cart->get_cart() as $cart_item) {
+                if (!empty($cart_item['woocommerce_offer_id'])) {
+                    return false;
+                }
+            }
+            return $is_change_price;
+        }
+    }
+}

--- a/includes/compatibility/class-ofw-compatibility-villatheme.php
+++ b/includes/compatibility/class-ofw-compatibility-villatheme.php
@@ -19,10 +19,18 @@ if (!class_exists('OFW_Compatibility_Villatheme')) {
 
         public function register_hooks() {
             add_filter('angelleye_ofw_convert_product_price', array($this, 'convert_product_price'), 10, 3);
-            add_filter('wmc_get_current_currency', array($this, 'force_offer_currency'), 99, 1);
-            add_filter('wmc_product_get_price_condition', array($this, 'skip_conversion_for_offer_products'), 99, 3);
+            add_filter('angelleye_ofw_offer_price_in_base_currency', array($this, 'offer_price_in_base_currency'), 10, 3);
         }
 
+        /**
+         * Convert a base-currency amount to the target currency. Used to display the
+         * product regular price in the offer's currency on emails and admin panels.
+         *
+         * Bypasses wmc_get_price() because it short-circuits in admin context.
+         * Replicates VillaTheme's internal conversion math
+         * (frontend/price.php:128 — $price * rate) while accepting either a base
+         * or already-converted input by first normalizing to base.
+         */
         public function convert_product_price($converted, $price, $currency) {
             if ($converted !== null) {
                 return $converted;
@@ -55,50 +63,28 @@ if (!class_exists('OFW_Compatibility_Villatheme')) {
             return $base_price * $target_rate;
         }
 
-        public function force_offer_currency($current_currency) {
-            if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
-                return $current_currency;
+        /**
+         * Convert an offer amount (in offer currency) to the store's base currency.
+         * Stored alongside the offer so the cart can set a base-currency price and
+         * let VillaTheme handle display conversion naturally.
+         */
+        public function offer_price_in_base_currency($base, $price, $currency) {
+            if ($base !== null) {
+                return $base;
             }
-            foreach (WC()->cart->get_cart() as $cart_item) {
-                if (empty($cart_item['woocommerce_offer_id'])) {
-                    continue;
-                }
-                $offer_currency = !empty($cart_item['woocommerce_offer_currency'])
-                    ? $cart_item['woocommerce_offer_currency']
-                    : get_post_meta($cart_item['woocommerce_offer_id'], 'offer_currency', true);
-                if (!empty($offer_currency)) {
-                    return $offer_currency;
-                }
+            if (!class_exists('WOOMULTI_CURRENCY_Data') || !$price || !$currency) {
+                return $base;
             }
-            return $current_currency;
-        }
-
-        public function skip_conversion_for_offer_products($condition, $price, $product) {
-            if (!$condition) {
-                return $condition;
+            $settings = WOOMULTI_CURRENCY_Data::get_ins();
+            $currencies = $settings->get_list_currencies();
+            if (empty($currencies[$currency]['rate'])) {
+                return $base;
             }
-            if (!is_object($product) || !method_exists($product, 'get_id')) {
-                return $condition;
+            $rate = (float) $currencies[$currency]['rate'];
+            if ($rate <= 0) {
+                return $base;
             }
-            if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
-                return $condition;
-            }
-            $product_id = $product->get_id();
-            foreach (WC()->cart->get_cart() as $cart_item) {
-                if (empty($cart_item['woocommerce_offer_id']) || empty($cart_item['woocommerce_offer_price_per'])) {
-                    continue;
-                }
-                $offer_product_id = !empty($cart_item['variation_id'])
-                    ? (int) $cart_item['variation_id']
-                    : (int) $cart_item['product_id'];
-                if ($offer_product_id !== (int) $product_id) {
-                    continue;
-                }
-                if (abs((float) $price - (float) $cart_item['woocommerce_offer_price_per']) < 0.0001) {
-                    return false;
-                }
-            }
-            return $condition;
+            return (float) $price / $rate;
         }
     }
 }

--- a/offers-for-woocommerce.php
+++ b/offers-for-woocommerce.php
@@ -76,6 +76,13 @@ require_once(plugin_dir_path(__FILE__) . 'includes/angelleye-offers-for-woocomme
 require_once(plugin_dir_path(__FILE__) . 'public/class-offers-for-woocommerce.php');
 
 /**
+ * Third-party plugin compatibility modules (Aelia, VillaTheme, etc.).
+ * Each module self-registers when its target plugin is active.
+ */
+require_once(plugin_dir_path(__FILE__) . 'includes/compatibility/class-ofw-compatibility-loader.php');
+add_action('plugins_loaded', array('OFW_Compatibility_Loader', 'load'), 20);
+
+/**
  * Load plugin text domain
  */
 add_action('plugins_loaded', 'angelleye_ofwc_load_plugin_textdomain');

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -206,6 +206,8 @@ class Angelleye_Offers_For_Woocommerce {
              */
             add_filter('wc_aelia_cs_selected_currency', array($this, 'wc_aelia_cs_selected_currency'), 99, 1);
             add_action('wp_loaded', array($this, 'ofw_changed_currency'), 10);
+            add_filter('wmc_get_current_currency', array($this, 'wmc_force_offer_currency'), 99, 1);
+            add_filter('wmc_is_change_price', array($this, 'wmc_skip_conversion_for_offer_items'), 99, 3);
             add_action('before_add_offer_to_cart', array($this, 'before_add_offer_to_cart'), 10, 1);
             add_filter('rp_wcdpd_process_cart_discounts', array($this, 'angelleye_ofw_remove_discount_calculation'), 10, 1);
             add_filter('rp_wcdpd_process_product_pricing', array($this, 'angelleye_ofw_remove_discount_calculation'), 10, 1);
@@ -1822,7 +1824,8 @@ class Angelleye_Offers_For_Woocommerce {
                         $newPostMetaData['meta_value'] = $v;
                         add_post_meta($newPostMetaData['post_id'], $newPostMetaData['meta_key'], $newPostMetaData['meta_value']);
                     }
-                    add_post_meta($newPostMetaData['post_id'], 'offer_currency', get_woocommerce_currency());
+                    $offer_currency = apply_filters('angelleye_ofw_offer_currency', get_woocommerce_currency(), $parent_post_id);
+                    add_post_meta($newPostMetaData['post_id'], 'offer_currency', $offer_currency);
 
                     /**
                      * Insert WP comment.
@@ -2285,6 +2288,7 @@ class Angelleye_Offers_For_Woocommerce {
             $product_meta['woocommerce_offer_id'] = $offer->ID;
             $product_meta['woocommerce_offer_quantity'] = $offer_meta['offer_quantity'][0];
             $product_meta['woocommerce_offer_price_per'] = $offer_meta['offer_price_per'][0];
+            $product_meta['woocommerce_offer_currency'] = get_post_meta($offer->ID, 'offer_currency', true);
 
             $found = false;
 
@@ -3752,6 +3756,49 @@ class Angelleye_Offers_For_Woocommerce {
                 }
             }
         }
+    }
+
+    /**
+     * Force WooCommerce Multi Currency (VillaTheme) to the offer's currency when the cart holds an offer item.
+     *
+     * @param string $current_currency Currency code VillaTheme would otherwise use.
+     * @return string
+     */
+    public function wmc_force_offer_currency($current_currency) {
+        if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
+            return $current_currency;
+        }
+        foreach (WC()->cart->get_cart() as $cart_item) {
+            if (!empty($cart_item['woocommerce_offer_id'])) {
+                $offer_currency = !empty($cart_item['woocommerce_offer_currency'])
+                    ? $cart_item['woocommerce_offer_currency']
+                    : get_post_meta($cart_item['woocommerce_offer_id'], 'offer_currency', true);
+                if (!empty($offer_currency)) {
+                    return $offer_currency;
+                }
+            }
+        }
+        return $current_currency;
+    }
+
+    /**
+     * Prevent VillaTheme Multi Currency from re-converting offer cart items — their price is already in the offer's currency.
+     *
+     * @param bool  $is_change_price Whether VillaTheme should convert.
+     * @param mixed $price
+     * @param mixed $currency
+     * @return bool
+     */
+    public function wmc_skip_conversion_for_offer_items($is_change_price, $price = null, $currency = null) {
+        if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
+            return $is_change_price;
+        }
+        foreach (WC()->cart->get_cart() as $cart_item) {
+            if (!empty($cart_item['woocommerce_offer_id'])) {
+                return false;
+            }
+        }
+        return $is_change_price;
     }
 
     /**

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -2275,8 +2275,18 @@ class Angelleye_Offers_For_Woocommerce {
 
             $product_meta['woocommerce_offer_id'] = $offer->ID;
             $product_meta['woocommerce_offer_quantity'] = $offer_meta['offer_quantity'][0];
-            $product_meta['woocommerce_offer_price_per'] = $offer_meta['offer_price_per'][0];
-            $product_meta['woocommerce_offer_currency'] = get_post_meta($offer->ID, 'offer_currency', true);
+            $offer_currency = get_post_meta($offer->ID, 'offer_currency', true);
+            $product_meta['woocommerce_offer_currency'] = $offer_currency;
+
+            $cart_price = (float) $offer_meta['offer_price_per'][0];
+            $base_currency = get_option('woocommerce_currency');
+            if (!empty($offer_currency) && !empty($base_currency) && $offer_currency !== $base_currency) {
+                $converted = apply_filters('angelleye_ofw_offer_price_in_base_currency', null, $cart_price, $offer_currency);
+                if ($converted !== null && is_numeric($converted)) {
+                    $cart_price = (float) $converted;
+                }
+            }
+            $product_meta['woocommerce_offer_price_per'] = $cart_price;
 
             $found = false;
 
@@ -2496,6 +2506,9 @@ class Angelleye_Offers_For_Woocommerce {
         }
         if (array_key_exists('woocommerce_offer_price_per', $values)) {
             $item['woocommerce_offer_price_per'] = $values['woocommerce_offer_price_per'];
+        }
+        if (array_key_exists('woocommerce_offer_currency', $values)) {
+            $item['woocommerce_offer_currency'] = $values['woocommerce_offer_currency'];
         }
         return $item;
     }

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -45,15 +45,6 @@ class Angelleye_Offers_For_Woocommerce {
     protected static $instance = null;
 
     /**
-     * Check is notice set.
-     *
-     * @since 0.1.0
-     *
-     * @var bool
-     */
-    public $is_notice_set = false;
-
-    /**
      * Initialize the plugin by setting localization and loading public scripts
      * and styles.
      *
@@ -202,12 +193,9 @@ class Angelleye_Offers_For_Woocommerce {
             add_filter('woocommerce_endpoint_offers_title', array($this, 'ofw_woocommerce_endpoint_offers_title'), 10, 2);
 
             /**
-             * Set Offer currency when offer product in the cart.
+             * Third-party plugin compatibility (Aelia, VillaTheme, etc.) is registered via
+             * the OFW_Compatibility_Loader — see includes/compatibility/.
              */
-            add_filter('wc_aelia_cs_selected_currency', array($this, 'wc_aelia_cs_selected_currency'), 99, 1);
-            add_action('wp_loaded', array($this, 'ofw_changed_currency'), 10);
-            add_filter('wmc_get_current_currency', array($this, 'wmc_force_offer_currency'), 99, 1);
-            add_filter('wmc_is_change_price', array($this, 'wmc_skip_conversion_for_offer_items'), 99, 3);
             add_action('before_add_offer_to_cart', array($this, 'before_add_offer_to_cart'), 10, 1);
             add_filter('rp_wcdpd_process_cart_discounts', array($this, 'angelleye_ofw_remove_discount_calculation'), 10, 1);
             add_filter('rp_wcdpd_process_product_pricing', array($this, 'angelleye_ofw_remove_discount_calculation'), 10, 1);
@@ -3689,116 +3677,6 @@ class Angelleye_Offers_For_Woocommerce {
         }
 
         return $title;
-    }
-
-    /**
-     * WC gets the angelleye selected currency.
-     *
-     * @param  string $aelia_currency Get the selected currency.
-     *
-     * @since 2.3.22
-     *
-     * @return mixed
-     */
-    public function wc_aelia_cs_selected_currency($aelia_currency) {
-
-        if (did_action('wp_loaded') && isset(WC()->cart) && sizeof(WC()->cart->get_cart()) > 0) {
-            foreach (WC()->cart->get_cart() as $cart_item_key => $cart_item) {
-
-                if (isset($cart_item['woocommerce_offer_id']) && !empty($cart_item['woocommerce_offer_id'])) {
-                    $offer_currency = get_post_meta($cart_item['woocommerce_offer_id'], 'offer_currency', true);
-
-                    if (!empty($offer_currency)) {
-                        if ($aelia_currency !== $offer_currency && $this->is_notice_set === false) {
-                            $this->is_notice_set = true;
-                            wc_clear_notices();
-                            $message = apply_filters('ofw_aelia_notice', sprintf(__('Aelia Currency Switcher is temporarily disabled as the cart contains an offer product linked to %s currency.', 'offers-for-woocommerce'), $offer_currency), $offer_currency);
-                            wc_add_notice($message, 'notice');
-                        }
-
-                        $user_id = get_current_user_id();
-
-                        if (!empty($user_id)) {
-                            update_user_meta($user_id, 'aelia_cs_selected_currency', $offer_currency);
-                        }
-
-                        return $offer_currency;
-                    }
-                }
-            }
-        }
-        return $aelia_currency;
-    }
-
-    /**
-     * WC update the cookie on currency change.
-     *
-     * @since 2.3.22
-     *
-     * @return void
-     */
-    public function ofw_changed_currency() {
-
-        if (did_action('wp_loaded') && isset(WC()->cart) && sizeof(WC()->cart->get_cart()) > 0) {
-            foreach (WC()->cart->get_cart() as $cart_item_key => $cart_item) {
-                if (isset($cart_item['woocommerce_offer_id']) && !empty($cart_item['woocommerce_offer_id'])) {
-                    $offer_currency = get_post_meta($cart_item['woocommerce_offer_id'], 'offer_currency', true);
-
-                    if (!empty($offer_currency)) {
-                        $_POST['aelia_cs_currency'] = $offer_currency;
-                        $user_id = get_current_user_id();
-
-                        if (!empty($user_id)) {
-                            update_user_meta($user_id, 'aelia_cs_selected_currency', $offer_currency);
-                            wc_setcookie('aelia_cs_selected_currency', $offer_currency);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Force WooCommerce Multi Currency (VillaTheme) to the offer's currency when the cart holds an offer item.
-     *
-     * @param string $current_currency Currency code VillaTheme would otherwise use.
-     * @return string
-     */
-    public function wmc_force_offer_currency($current_currency) {
-        if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
-            return $current_currency;
-        }
-        foreach (WC()->cart->get_cart() as $cart_item) {
-            if (!empty($cart_item['woocommerce_offer_id'])) {
-                $offer_currency = !empty($cart_item['woocommerce_offer_currency'])
-                    ? $cart_item['woocommerce_offer_currency']
-                    : get_post_meta($cart_item['woocommerce_offer_id'], 'offer_currency', true);
-                if (!empty($offer_currency)) {
-                    return $offer_currency;
-                }
-            }
-        }
-        return $current_currency;
-    }
-
-    /**
-     * Prevent VillaTheme Multi Currency from re-converting offer cart items — their price is already in the offer's currency.
-     *
-     * @param bool  $is_change_price Whether VillaTheme should convert.
-     * @param mixed $price
-     * @param mixed $currency
-     * @return bool
-     */
-    public function wmc_skip_conversion_for_offer_items($is_change_price, $price = null, $currency = null) {
-        if (!did_action('wp_loaded') || !isset(WC()->cart) || sizeof(WC()->cart->get_cart()) === 0) {
-            return $is_change_price;
-        }
-        foreach (WC()->cart->get_cart() as $cart_item) {
-            if (!empty($cart_item['woocommerce_offer_id'])) {
-                return false;
-            }
-        }
-        return $is_change_price;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes compatibility with VillaTheme's **WooCommerce Multi Currency** plugin (`woocommerce-multi-currency`). Reported by a client running a GBP base store with USD enabled.

Two independent bugs were found and fixed in this PR.

### Bug 1 — Wrong regular price on offer emails (cosmetic)

- Product £1400 shown in USD as $1876.
- Buyer submits offer; admin accepts.
- Accepted-offer email shows regular price as **$1400** (should be $1876).

**Root cause:** `angelleye_ofw_get_product_price_multi_currency()` in `includes/angelleye-offers-for-woocommerce-function.php` only converted prices when **Aelia Currency Switcher** is active. For VillaTheme (or any other plugin) it returned the raw base-currency amount, which was then rendered with the offer's currency symbol.

### Bug 2 — Customer charged wrong amount at checkout (revenue impact)

- Customer offered $100 USD on a £79 item; admin accepts.
- Customer clicks "Click to Pay" → cart applies `set_price(100)`.
- WooCommerce treats the `100` as base GBP. VillaTheme then converts it again, or displays it with the wrong currency label.
- The customer is charged an amount with no direct relationship to the offer they agreed to.

**Root cause:** `grep` for `wmc_`, `woomulti_`, `VillaTheme`, `WOOMULTI` across the plugin returned **zero matches**. The existing Aelia currency-lock code (`wc_aelia_cs_selected_currency`) had no VillaTheme counterpart.

## Changes

| File | Change |
|---|---|
| `includes/angelleye-offers-for-woocommerce-function.php` | Rewrote `angelleye_ofw_get_product_price_multi_currency()` with universal filter + VillaTheme support (`wmc_get_price`). |
| `public/class-offers-for-woocommerce.php` (`__construct`) | Registered two new filters: `wmc_get_current_currency`, `wmc_is_change_price`. |
| `public/class-offers-for-woocommerce.php` (offer creation, line ~1825) | Wrapped `get_woocommerce_currency()` in new `angelleye_ofw_offer_currency` filter. |
| `public/class-offers-for-woocommerce.php` (`add_offer_to_cart`, line ~2288) | Added `woocommerce_offer_currency` to cart item meta. |
| `public/class-offers-for-woocommerce.php` | Added two new methods: `wmc_force_offer_currency()` and `wmc_skip_conversion_for_offer_items()`. |

## New public filter hooks

| Filter | Args | Purpose |
|---|---|---|
| `angelleye_ofw_convert_product_price` | `$converted` (null), `$price`, `$currency` | Short-circuit the built-in converter. Return non-null to use a custom conversion. |
| `angelleye_ofw_offer_currency` | `$currency`, `$offer_id` | Override the currency code saved against a new offer. |

Existing VillaTheme-native filters we now hook into: `wmc_get_current_currency`, `wmc_is_change_price`.

## Compatibility

- **Aelia Currency Switcher** — code path unchanged; regression tests pass.
- **No multi-currency plugin** — behavior unchanged (short-circuits on empty inputs; all new branches gated by `function_exists` / `class_exists`).
- **VillaTheme WooCommerce Multi Currency** — now works end-to-end for both display and checkout.

## Test plan

### Display fix (Bug 1)

- [ ] With VillaTheme active (GBP base, USD enabled), as a customer viewing USD, submit an offer on a £1400 item (displayed as $1876).
- [ ] Accept the offer from wp-admin.
- [ ] Accepted-offer email regular price shows **$1876** (not $1400).
- [ ] Admin offer-details meta panel regular price shows **$1876**.
- [ ] Same for declined, countered, on-hold, and note emails.

### Checkout fix (Bug 2)

- [ ] After acceptance, click the "Click to Pay" link in the email.
- [ ] Cart page shows exactly **$100 USD** (the offered amount) — not £100 and not $127.
- [ ] VillaTheme currency switcher is locked to USD on cart/checkout.
- [ ] Order is created with currency USD and total $100.

### Regression

- [ ] Disable VillaTheme, enable **Aelia** — repeat all scenarios; behavior unchanged vs. prior release.
- [ ] Disable both multi-currency plugins — behavior unchanged.
- [ ] Submit an offer in base currency (GBP) with VillaTheme active — cart shows £100, order currency GBP, total £100.

