### PR TITLE
Reduce timeout for plugin notification request from 45s to 5s

### DIFF
--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -4902,7 +4902,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         $api_url .= '&action=angelleye_get_plugin_notification';
         $request = wp_remote_post($api_url, array(
             'method' => 'POST',
-            'timeout' => 45,
+            'timeout' => 5,
             'redirection' => 5,
             'httpversion' => '1.0',
             'blocking' => true,


### PR DESCRIPTION
## Summary

This PR reduces the timeout for the `angelleye_get_plugin_notification` request from 45 seconds to 5 seconds to prevent admin interface outages when the notification endpoint becomes unresponsive.

## Problem

When `https://www.angelleye.com/?Wordpress_Plugin_Notification_Sender&action=angelleye_get_plugin_notification` becomes slow or unresponsive, the long timeout causes admin interfaces across all sites using this plugin to hang. During a recent outage of this endpoint, numerous admin dashboards became unusable as they waited up to 45 seconds (or longer in some configurations) for the request to complete or fail.

This is a critical reliability issue — a single external endpoint should never be able to take down customer admin interfaces. A non-essential notification check should fail fast and degrade gracefully rather than blocking the entire admin UI.

## Changes

- Reduced the HTTP request timeout for the plugin notification fetch from `45` seconds to `5` seconds.

## Impact

- **Before:** If the notification endpoint is slow/down, admin pages hang for up to 45 seconds per request.
- **After:** Failed or slow notification requests time out after 5 seconds, allowing the admin interface to load normally even when the remote endpoint is unavailable.

The notification feature is non-critical, so failing fast is strictly preferable to blocking the admin experience. 5 seconds is more than sufficient for a healthy endpoint to respond while ensuring admins are never significantly delayed by a remote outage.

## Testing

- Verified admin pages load normally when the notification endpoint is reachable.
- Verified admin pages load within ~5 seconds (instead of hanging) when the notification endpoint is unreachable or slow to respond.

## Related Issue

Resolves the user-reported outage where the plugin notification request took down multiple admin interfaces due to the absence of a reasonable timeout.