### PR TITLE
Reafctored Admin push notification feature

### DIFF
--- a/admin/assets/js/offers-for-woocommerce-admin.js
+++ b/admin/assets/js/offers-for-woocommerce-admin.js
@@ -1,30 +1,11 @@
 jQuery(function ($) {
-    document.addEventListener("DOMContentLoaded", function(){
-
-        jQuery('[id^=angelleye_notification]').each(function (i) {
+    document.addEventListener("DOMContentLoaded", function () {
+        jQuery('[id^=angelleye_notification]').each(function () {
             jQuery('[id="' + this.id + '"]').slice(1).remove();
         });
 
-        var el_notice = document.getElementsByClassName('angelleye-notice');
-        el_notice.fadeIn(750);
-
-        $(document).on('click', '.angelleye-notice-dismiss', function (e){
-            e.preventDefault();
-            jQuery(this).parent().parent(".angelleye-notice").fadeOut(600, function () {
-                jQuery(this).parent().parent(".angelleye-notice").remove();
-            });
-            notify_wordpress(jQuery(this).data("msg"));
-        });
-
+        jQuery('.angelleye-notice').fadeIn(750);
     });
-
-    function notify_wordpress(message) {
-        var param = {
-            action: 'angelleye_offers_for_woocommerce_adismiss_notice',
-            data: message
-        };
-        jQuery.post(ajaxurl, param);
-    }
 });
 
 

--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -469,8 +469,6 @@ class Angelleye_Offers_For_Woocommerce_Admin {
          */
         add_action('trashed_post', array($this, 'ofw_before_offers_trash_action'), 10, 1);
 
-        add_action('wp_ajax_angelleye_offers_for_woocommerce_adismiss_notice', array($this, 'angelleye_offers_for_woocommerce_adismiss_notice'), 10);
-        add_action('admin_notices', array($this, 'angelleye_offers_for_woocommerce_display_push_notification'), 10);
         add_action('angelleye_offer_for_woocommerce_admin_add_offer', array($this, 'angelleye_offer_for_woocommerce_admin_add_offer'), 10, 1);
         add_action('admin_action_editpost', array($this, 'angelleye_offer_for_woocommerce_admin_save_offer'), 10);
         add_action('angelleye_display_extra_product_details', array($this, 'angelleye_offer_for_woocommerce_display_product_extra_details'), 10, 1);
@@ -4860,106 +4858,6 @@ class Angelleye_Offers_For_Woocommerce_Admin {
     public static function ofwc_format_localized_price($value) {
         $newVal = str_replace(wc_get_price_thousand_separator(), '', strval($value));
         return str_replace(wc_get_price_decimal_separator(), '.', strval($newVal));
-    }
-
-    /**
-     * Add Notification message with format.
-     *
-     * @since 0.1.0
-     *
-     * @return void
-     */
-    public function angelleye_offers_for_woocommerce_display_push_notification() {
-        global $current_user;
-        $user_id = $current_user->ID;
-        if (false === ( $response = get_transient('angelleye_offers_push_notification_result') )) {
-            $response = $this->angelleye_get_push_notifications();
-            if (is_object($response)) {
-                set_transient('angelleye_offers_push_notification_result', $response, 12 * HOUR_IN_SECONDS);
-            }
-        }
-        if (is_object($response)) {
-            foreach ($response->data as $key => $response_data) {
-                if (!get_user_meta($user_id, $response_data->id)) {
-                    $this->angelleye_display_push_notification($response_data);
-                }
-            }
-        }
-    }
-
-    /**
-     * Display push notification message.
-     *
-     * @since 0.1.0
-     *
-     * @return false|mixed
-     */
-    public function angelleye_get_push_notifications() {
-        $args = array(
-            'plugin_name' => 'offers-for-woocommerce',
-        );
-        $api_url = PAYPAL_FOR_WOOCOMMERCE_PUSH_NOTIFICATION_WEB_URL . '?Wordpress_Plugin_Notification_Sender';
-        $api_url .= '&action=angelleye_get_plugin_notification';
-        $request = wp_remote_post($api_url, array(
-            'method' => 'POST',
-            'timeout' => 5,
-            'redirection' => 5,
-            'httpversion' => '1.0',
-            'blocking' => true,
-            'headers' => array('user-agent' => 'AngellEYE'),
-            'body' => $args,
-            'cookies' => array(),
-            'sslverify' => false
-        ));
-        if (is_wp_error($request) or wp_remote_retrieve_response_code($request) != 200) {
-            return false;
-        }
-        if ($request != '') {
-            $response = json_decode(wp_remote_retrieve_body($request));
-        } else {
-            $response = false;
-        }
-        return $response;
-    }
-
-    /**
-     * Preparing message in html format.
-     *
-     * @since 0.1.0
-     *
-     * @param object $response_data Get the response object.
-     * @return void
-     */
-    public function angelleye_display_push_notification($response_data) {
-        echo '<div class="notice notice-success angelleye-notice" style="display:none;" id="' . $response_data->id . '">'
-        . '<div class="angelleye-notice-logo-push"><span> <img alt="company-logo" src="' . $response_data->ans_company_logo . '"> </span></div>'
-        . '<div class="angelleye-notice-message">'
-        . '<h3>' . $response_data->ans_message_title . '</h3>'
-        . '<div class="angelleye-notice-message-inner">'
-        . '<p>' . $response_data->ans_message_description . '</p>'
-        . '<div class="angelleye-notice-action"><a target="_blank" href="' . $response_data->ans_button_url . '" class="button button-primary">' . $response_data->ans_button_label . '</a></div>'
-        . '</div>'
-        . '</div>'
-        . '<div class="angelleye-notice-cta">'
-        . '<button class="angelleye-notice-dismiss angelleye-dismiss-welcome" data-msg="' . $response_data->id . '">Dismiss</button>'
-        . '</div>'
-        . '</div>';
-    }
-
-    /**
-     * Dismiss the offer for the WooCommerce notice message.
-     *
-     * @since 0.1.0
-     *
-     * @return void
-     */
-    public function angelleye_offers_for_woocommerce_adismiss_notice() {
-        global $current_user;
-        $user_id = $current_user->ID;
-        if (!empty($_POST['action']) && $_POST['action'] == 'angelleye_offers_for_woocommerce_adismiss_notice') {
-            add_user_meta($user_id, wc_clean($_POST['data']), 'true', true);
-            wp_send_json_success();
-        }
     }
 
     /**

--- a/includes/notifications/class-angelleye-push-notifications.php
+++ b/includes/notifications/class-angelleye-push-notifications.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * AngellEYE Push Notifications.
+ *
+ * Self-contained reusable class for fetching and displaying admin notifications
+ * pushed from angelleye.com. Designed to be copy-pasted into any AngellEYE plugin.
+ *
+ * Usage in a plugin's bootstrap:
+ *
+ *     require_once __DIR__ . '/includes/notifications/class-angelleye-push-notifications.php';
+ *     add_action( 'plugins_loaded', function () {
+ *         ( new AngellEYE_Push_Notifications( array(
+ *             'plugin_slug' => 'my-plugin-slug',
+ *         ) ) )->register();
+ *     }, 25 );
+ *
+ * Optional config:
+ *   - api_url       (string)   Override the remote endpoint base.
+ *   - timeout       (int)      HTTP timeout in seconds. Default 5.
+ *   - success_ttl   (int)      Cache TTL on success. Default 12 hours.
+ *   - failure_ttl   (int)      Cache TTL on failure. Default 4 hours.
+ *   - applies_to    (callable) fn( $notification, $plugin_slug ): bool — filter which
+ *                              notifications are shown to the current admin.
+ *
+ * @package angelleye-shared
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'AngellEYE_Push_Notifications' ) ) {
+
+    class AngellEYE_Push_Notifications {
+
+        const VERSION    = '1.0.0';
+        const API_BASE   = 'https://www.angelleye.com/';
+        const USER_AGENT = 'AngellEYE';
+
+        private $plugin_slug;
+        private $api_url;
+        private $timeout;
+        private $success_ttl;
+        private $failure_ttl;
+        private $applies_to;
+        private $dismiss_action;
+
+        private static $script_printed = false;
+
+        public function __construct( array $args ) {
+            if ( empty( $args['plugin_slug'] ) ) {
+                _doing_it_wrong( __METHOD__, 'plugin_slug is required.', '1.0.0' );
+                $args['plugin_slug'] = 'unknown';
+            }
+            $this->plugin_slug    = sanitize_key( $args['plugin_slug'] );
+            $this->api_url        = isset( $args['api_url'] ) ? $args['api_url'] : self::API_BASE;
+            $this->timeout        = isset( $args['timeout'] ) ? (int) $args['timeout'] : 5;
+            $this->success_ttl    = isset( $args['success_ttl'] ) ? (int) $args['success_ttl'] : 12 * HOUR_IN_SECONDS;
+            $this->failure_ttl    = isset( $args['failure_ttl'] ) ? (int) $args['failure_ttl'] : 4 * HOUR_IN_SECONDS;
+            $this->applies_to     = isset( $args['applies_to'] ) && is_callable( $args['applies_to'] ) ? $args['applies_to'] : null;
+            $this->dismiss_action = 'angelleye_dismiss_notice_' . $this->plugin_slug;
+        }
+
+        public function register() {
+            add_action( 'admin_notices', array( $this, 'display_admin_notices' ) );
+            add_action( 'wp_ajax_' . $this->dismiss_action, array( $this, 'handle_dismiss' ) );
+            add_action( 'admin_print_footer_scripts', array( $this, 'print_dismiss_script' ) );
+        }
+
+        /**
+         * Fetch push notifications, with success + failure transient caching.
+         *
+         * @return object|false
+         */
+        public function get_push_notifications() {
+            $success_key = $this->transient_key( 'success' );
+            $failure_key = $this->transient_key( 'failure' );
+
+            $cached = get_transient( $success_key );
+            if ( false !== $cached ) {
+                return $cached;
+            }
+            if ( false !== get_transient( $failure_key ) ) {
+                return false;
+            }
+
+            $endpoint = trailingslashit( $this->api_url ) . '?Wordpress_Plugin_Notification_Sender&action=angelleye_get_plugin_notification';
+
+            $response = wp_remote_post( $endpoint, array(
+                'method'      => 'POST',
+                'timeout'     => $this->timeout,
+                'redirection' => 5,
+                'httpversion' => '1.0',
+                'blocking'    => true,
+                'headers'     => array( 'user-agent' => self::USER_AGENT ),
+                'body'        => array( 'plugin_name' => $this->plugin_slug ),
+                'cookies'     => array(),
+                'sslverify'   => false,
+            ) );
+
+            if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+                set_transient( $failure_key, time(), $this->failure_ttl );
+                return false;
+            }
+
+            $body   = wp_remote_retrieve_body( $response );
+            $parsed = $body ? json_decode( $body ) : false;
+
+            if ( $parsed ) {
+                set_transient( $success_key, $parsed, $this->success_ttl );
+                delete_transient( $failure_key );
+                return $parsed;
+            }
+
+            set_transient( $failure_key, time(), $this->failure_ttl );
+            return false;
+        }
+
+        public function display_admin_notices() {
+            if ( ! is_user_logged_in() ) {
+                return;
+            }
+
+            $response = $this->get_push_notifications();
+            if ( ! is_object( $response ) || empty( $response->data ) || ! is_array( $response->data ) ) {
+                return;
+            }
+
+            $user_id = get_current_user_id();
+
+            foreach ( $response->data as $notification ) {
+                if ( empty( $notification->id ) ) {
+                    continue;
+                }
+                if ( get_user_meta( $user_id, $notification->id, true ) ) {
+                    continue;
+                }
+                if ( $this->applies_to && ! call_user_func( $this->applies_to, $notification, $this->plugin_slug ) ) {
+                    continue;
+                }
+                $this->render_notification( $notification );
+            }
+        }
+
+        public function render_notification( $n ) {
+            $id          = isset( $n->id ) ? $n->id : '';
+            $logo        = isset( $n->ans_company_logo ) ? $n->ans_company_logo : '';
+            $title       = isset( $n->ans_message_title ) ? $n->ans_message_title : '';
+            $description = isset( $n->ans_message_description ) ? $n->ans_message_description : '';
+            $btn_url     = isset( $n->ans_button_url ) ? $n->ans_button_url : '';
+            $btn_label   = isset( $n->ans_button_label ) ? $n->ans_button_label : '';
+            ?>
+            <div class="notice notice-success angelleye-notice" style="display:none;" id="<?php echo esc_attr( $id ); ?>" data-angelleye-action="<?php echo esc_attr( $this->dismiss_action ); ?>">
+                <?php if ( $logo ) : ?>
+                <div class="angelleye-notice-logo-push"><span><img alt="" src="<?php echo esc_url( $logo ); ?>" /></span></div>
+                <?php endif; ?>
+                <div class="angelleye-notice-message">
+                    <h3><?php echo esc_html( $title ); ?></h3>
+                    <div class="angelleye-notice-message-inner">
+                        <p><?php echo esc_html( $description ); ?></p>
+                        <?php if ( $btn_url && $btn_label ) : ?>
+                        <div class="angelleye-notice-action">
+                            <a target="_blank" href="<?php echo esc_url( $btn_url ); ?>" class="button button-primary"><?php echo esc_html( $btn_label ); ?></a>
+                        </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+                <div class="angelleye-notice-cta">
+                    <button type="button" class="angelleye-notice-dismiss angelleye-dismiss-welcome" data-msg="<?php echo esc_attr( $id ); ?>" data-action="<?php echo esc_attr( $this->dismiss_action ); ?>">Dismiss</button>
+                </div>
+            </div>
+            <?php
+        }
+
+        public function handle_dismiss() {
+            if ( ! is_user_logged_in() ) {
+                wp_send_json_error();
+            }
+            $message_id = isset( $_POST['data'] ) ? wc_clean( wp_unslash( $_POST['data'] ) ) : '';
+            if ( '' === $message_id ) {
+                wp_send_json_error();
+            }
+            add_user_meta( get_current_user_id(), $message_id, 'true', true );
+            wp_send_json_success();
+        }
+
+        /**
+         * Print one inline dismiss handler that works for every AngellEYE_Push_Notifications
+         * instance on the page (each notice carries its own data-action).
+         */
+        public function print_dismiss_script() {
+            if ( self::$script_printed ) {
+                return;
+            }
+            self::$script_printed = true;
+            ?>
+            <script type="text/javascript">
+            (function ($) {
+                $(document).on('click', '.angelleye-notice-dismiss', function (e) {
+                    e.preventDefault();
+                    var $btn   = $(this);
+                    var msg    = $btn.data('msg');
+                    var action = $btn.data('action');
+                    if (!action) { return; }
+                    $btn.closest('.angelleye-notice').fadeOut(600, function () { $(this).remove(); });
+                    $.post(ajaxurl, { action: action, data: msg });
+                });
+            })(jQuery);
+            </script>
+            <?php
+        }
+
+        private function transient_key( $type ) {
+            return 'angelleye_push_notification_' . $type . '_' . md5( $this->plugin_slug );
+        }
+    }
+}

--- a/offers-for-woocommerce.php
+++ b/offers-for-woocommerce.php
@@ -83,6 +83,19 @@ require_once(plugin_dir_path(__FILE__) . 'includes/compatibility/class-ofw-compa
 add_action('plugins_loaded', array('OFW_Compatibility_Loader', 'load'), 20);
 
 /**
+ * Shared AngellEYE push-notifications class. Self-contained — copy the file as-is
+ * into other AngellEYE plugins; the class_exists guard ensures only one copy loads.
+ */
+require_once(plugin_dir_path(__FILE__) . 'includes/notifications/class-angelleye-push-notifications.php');
+add_action('plugins_loaded', function () {
+    if (is_admin() && class_exists('AngellEYE_Push_Notifications')) {
+        (new AngellEYE_Push_Notifications(array(
+            'plugin_slug' => 'offers-for-woocommerce',
+        )))->register();
+    }
+}, 25);
+
+/**
  * Load plugin text domain
  */
 add_action('plugins_loaded', 'angelleye_ofwc_load_plugin_textdomain');


### PR DESCRIPTION
## Summary

Extracts the push-notification fetch / render / dismiss logic from the offers admin class into a self-contained reusable class — `AngellEYE_Push_Notifications`.

## Why

The same fetch / render / dismiss code existed in slightly different forms across our plugins:

| Aspect | PayPal for WooCommerce | Offers for WooCommerce (before) |
|---|---|---|
| Cache strategy | success transient (12 h) + failure transient (4 h) | success transient only (12 h) |
| Timeout | 4 s | 5 s |
| AJAX action | `angelleye_dismiss_notice` | `angelleye_offers_for_woocommerce_adismiss_notice` |
| Output escaping | none | none |
| JS handler | bound directly | event-delegated |

A non-essential, slow notification endpoint could hang the WP admin (already partially mitigated in #527 by lowering the timeout from 45 s to 5 s) and we kept porting fixes by hand into each plugin. Consolidating into one file fixes the divergence and makes the next round of plugins trivially simple to update.

## What's in the new class

`includes/notifications/class-angelleye-push-notifications.php` — single file, no external dependencies.

```php
( new AngellEYE_Push_Notifications( array(
    'plugin_slug' => 'offers-for-woocommerce',
    // optional: api_url, timeout, success_ttl, failure_ttl, applies_to
) ) )->register();
```

| Method | Hook | Behavior |
|---|---|---|
| `get_push_notifications()` | — | POSTs to `angelleye.com` notification endpoint with the configured slug. Caches success for 12 h and failure for 4 h via transient keys derived from the slug — prevents hammering a slow endpoint. |
| `display_admin_notices()` | `admin_notices` | Iterates the response, skips notifications already dismissed (per-user meta), optionally consults a configurable `applies_to` callback (used by PFW for its gateway-enabled check), and renders each surviving notification with proper `esc_html` / `esc_url` / `esc_attr` escaping. |
| `handle_dismiss()` | `wp_ajax_angelleye_dismiss_notice_<slug>` | Stores `user_meta($user_id, $notification_id, 'true', true)`. Action name is namespaced per plugin so multiple AngellEYE plugins coexist. |
| `print_dismiss_script()` | `admin_print_footer_scripts` | Prints one shared dismiss handler. Uses a static `$script_printed` flag so multiple plugins on the same page print it only once. Each notice carries its own `data-action`, so the same listener routes to the correct AJAX endpoint. |

The `class_exists( 'AngellEYE_Push_Notifications' )` guard means whichever plugin's copy loads first defines the class — they all use the same constructor-configured API, so the loaded copy serves every instance.

## Files changed

| File | Change |
|---|---|
| `includes/notifications/class-angelleye-push-notifications.php` | **New.** The reusable class. |
| `offers-for-woocommerce.php` | Requires the new class file and registers an instance for `plugin_slug = offers-for-woocommerce` on `plugins_loaded` priority 25 in admin context. |
| `admin/class-offers-for-woocommerce-admin.php` | Removed `angelleye_get_push_notifications()`, `angelleye_offers_for_woocommerce_display_push_notification()`, `angelleye_display_push_notification()`, `angelleye_offers_for_woocommerce_adismiss_notice()` and the two `add_action` registrations for `admin_notices` and `wp_ajax_…_adismiss_notice`. |
| `admin/assets/js/offers-for-woocommerce-admin.js` | Removed the hand-rolled dismiss handler and `notify_wordpress()` helper. Dismiss is now handled by the inline script printed by the class. |

## Test plan

- [ ] In wp-admin, with no notifications cached, a fresh page load fetches and renders any pending notifications. Confirm via Network tab that the request fires once and is then served from transient on subsequent loads (no second request within 12 h).
- [ ] Clicking Dismiss fades out the notice, posts to `admin-ajax.php?action=angelleye_dismiss_notice_offers-for-woocommerce`, and the notice does not return on reload (user meta persisted).
- [ ] Force a remote-endpoint failure (e.g., block the host via hosts file). Confirm:
  - First request fails fast (≤ 5 s timeout).
  - Failure transient is set; subsequent admin pages within 4 h do not retry.
- [ ] No PHP notices/warnings in `debug.log` during any of the above.
- [ ] `php -l` passes on all modified PHP files.
- [ ] Browser console is clean during dismiss.
