### PR TITLE
Fix: Enforce offer expiration in cart and checkout

### DIFF
--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -1454,21 +1454,20 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         if ("edit-woocommerce_offer" == $screen->id) {
             global $wpdb;
 
-            $target_now_date = date("Y-m-d H:i:s", current_time('timestamp', 0));
-
-            $expired_offers = $wpdb->get_results($wpdb->prepare("SELECT post_id, meta_value FROM $wpdb->postmeta WHERE `meta_key` = '%s' AND `meta_value` <> ''", 'offer_expiration_date'), 'ARRAY_A');
-            if (($expired_offers) && !empty($expired_offers)) {
-                foreach ($expired_offers as $v) {
-                    $offer_expire_date_formatted = date("Y-m-d 23:59:59", strtotime($v['meta_value']));
-                    if ($offer_expire_date_formatted <= $target_now_date) {
-                        $post_status = get_post_status($v['post_id']);
-                        if ($post_status && $post_status != 'trash') {
-                            $target_post = array(
-                                'ID' => $v['post_id'],
-                                'post_status' => 'expired-offer'
-                            );
-                            wp_update_post($target_post);
-                        }
+            // Defer the cut-off rule to the central helper so this legacy
+            // fallback stays in lockstep with cron / cart / checkout.
+            $expired_offers = $wpdb->get_col($wpdb->prepare("SELECT post_id FROM $wpdb->postmeta WHERE `meta_key` = %s AND `meta_value` <> ''", 'offer_expiration_date'));
+            if (!empty($expired_offers) && class_exists('OFW_Offer_Expiration')) {
+                foreach ($expired_offers as $post_id) {
+                    if (!OFW_Offer_Expiration::is_expired($post_id)) {
+                        continue;
+                    }
+                    $post_status = get_post_status($post_id);
+                    if ($post_status && $post_status != 'trash') {
+                        wp_update_post(array(
+                            'ID' => (int) $post_id,
+                            'post_status' => 'expired-offer',
+                        ));
                     }
                 }
             }

--- a/includes/class-ofw-offer-expiration.php
+++ b/includes/class-ofw-offer-expiration.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Offer expiration enforcement.
+ *
+ * Single source of truth for "is this offer expired?" and the place where
+ * that rule is enforced across the lifecycle:
+ *
+ *   - Scheduled cron sweep flips past-date offers to `expired-offer` status
+ *     so the rest of the codebase can rely on post_status without depending
+ *     on an admin loading the offers list (the legacy fallback).
+ *   - Cart validation strips line items tied to expired offers on every
+ *     cart/checkout render.
+ *   - Checkout validation produces a hard error if an expired offer somehow
+ *     survives into the order-placement step.
+ *
+ * Expiration uses end-of-day semantics (23:59:59 in the site timezone) to stay
+ * consistent with the legacy admin sweep and the email-link handler — a single
+ * cut-off avoids merchants seeing different behavior in different code paths.
+ *
+ * @package Angelleye_Offers_For_Woocommerce
+ * @since   3.1.3
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!class_exists('OFW_Offer_Expiration')) {
+
+    class OFW_Offer_Expiration {
+
+        const CRON_HOOK          = 'ofw_sweep_expired_offers';
+        const META_KEY           = 'offer_expiration_date';
+        const EXPIRED_STATUS     = 'expired-offer';
+        const OFFER_POST_TYPE    = 'woocommerce_offer';
+        const NOTICE_GROUP       = 'ofw_expired_offer';
+
+        /**
+         * Wire runtime hooks. Called once from the plugin bootstrap.
+         */
+        public static function register() {
+            add_action(self::CRON_HOOK, array(__CLASS__, 'sweep_expired_offers'));
+
+            // WC fires this on cart, checkout, and AJAX cart updates — the right
+            // place to keep cart contents in sync with offer validity.
+            add_action('woocommerce_check_cart_items', array(__CLASS__, 'remove_expired_cart_items'), 5);
+
+            // WC's documented hook for adding errors that must block checkout.
+            add_action('woocommerce_after_checkout_validation', array(__CLASS__, 'validate_checkout_offers'), 10, 2);
+        }
+
+        /**
+         * Plugin activation — schedule the recurring sweep.
+         */
+        public static function activate() {
+            if (!wp_next_scheduled(self::CRON_HOOK)) {
+                wp_schedule_event(time() + MINUTE_IN_SECONDS, 'hourly', self::CRON_HOOK);
+            }
+        }
+
+        /**
+         * Plugin deactivation — unschedule the recurring sweep.
+         */
+        public static function deactivate() {
+            wp_clear_scheduled_hook(self::CRON_HOOK);
+        }
+
+        /**
+         * Whether the given offer has passed its expiration date.
+         *
+         * Returns false when no expiration meta is set so open-ended offers
+         * continue to behave as they always have.
+         *
+         * @param int $offer_id
+         * @return bool
+         */
+        public static function is_expired($offer_id) {
+            $offer_id = absint($offer_id);
+            if (!$offer_id) {
+                return false;
+            }
+
+            $cutoff = self::get_expiration_cutoff($offer_id);
+            if (!$cutoff) {
+                return false;
+            }
+
+            return $cutoff <= current_time('timestamp', 0);
+        }
+
+        /**
+         * Site-local Unix timestamp at which the offer becomes invalid (inclusive
+         * of the calendar day stored in meta). False when the offer has no
+         * expiration set.
+         *
+         * @param int $offer_id
+         * @return int|false
+         */
+        public static function get_expiration_cutoff($offer_id) {
+            $raw = get_post_meta(absint($offer_id), self::META_KEY, true);
+            if (empty($raw)) {
+                return false;
+            }
+
+            $parsed = strtotime($raw);
+            if (!$parsed) {
+                return false;
+            }
+
+            return strtotime(date('Y-m-d 23:59:59', $parsed));
+        }
+
+        /**
+         * Cron callback: flip every past-date offer that is still in an active
+         * status to `expired-offer` in a single pass.
+         */
+        public static function sweep_expired_offers() {
+            global $wpdb;
+
+            $now_mysql = current_time('mysql');
+
+            $rows = $wpdb->get_results($wpdb->prepare(
+                "SELECT pm.post_id, pm.meta_value
+                   FROM {$wpdb->postmeta} pm
+                   INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+                  WHERE pm.meta_key = %s
+                    AND pm.meta_value <> ''
+                    AND p.post_type = %s
+                    AND p.post_status NOT IN ('trash', %s)",
+                self::META_KEY,
+                self::OFFER_POST_TYPE,
+                self::EXPIRED_STATUS
+            ), ARRAY_A);
+
+            if (empty($rows)) {
+                return;
+            }
+
+            foreach ($rows as $row) {
+                $parsed = strtotime($row['meta_value']);
+                if (!$parsed) {
+                    continue;
+                }
+
+                $cutoff_mysql = date('Y-m-d 23:59:59', $parsed);
+                if ($cutoff_mysql > $now_mysql) {
+                    continue;
+                }
+
+                wp_update_post(array(
+                    'ID'          => (int) $row['post_id'],
+                    'post_status' => self::EXPIRED_STATUS,
+                ));
+
+                do_action('ofw_offer_expired', (int) $row['post_id']);
+            }
+        }
+
+        /**
+         * Remove any cart item whose linked offer has expired and surface a
+         * single grouped notice. Bail safely if WC isn't fully booted.
+         */
+        public static function remove_expired_cart_items() {
+            if (!function_exists('WC') || is_null(WC()->cart)) {
+                return;
+            }
+
+            $removed = 0;
+            foreach (WC()->cart->get_cart() as $cart_item_key => $cart_item) {
+                if (empty($cart_item['woocommerce_offer_id'])) {
+                    continue;
+                }
+                if (!self::is_expired($cart_item['woocommerce_offer_id'])) {
+                    continue;
+                }
+
+                WC()->cart->remove_cart_item($cart_item_key);
+                $removed++;
+            }
+
+            if ($removed > 0 && !wc_has_notice(self::expired_notice_text(), 'error')) {
+                wc_add_notice(self::expired_notice_text(), 'error');
+            }
+        }
+
+        /**
+         * Checkout-time validation: add a hard error so WC cancels the order.
+         *
+         * @param array     $posted_data
+         * @param WP_Error  $errors
+         */
+        public static function validate_checkout_offers($posted_data, $errors) {
+            if (!function_exists('WC') || is_null(WC()->cart) || !is_wp_error($errors)) {
+                return;
+            }
+
+            $has_expired = false;
+            foreach (WC()->cart->get_cart() as $cart_item_key => $cart_item) {
+                if (empty($cart_item['woocommerce_offer_id'])) {
+                    continue;
+                }
+                if (!self::is_expired($cart_item['woocommerce_offer_id'])) {
+                    continue;
+                }
+
+                WC()->cart->remove_cart_item($cart_item_key);
+                $has_expired = true;
+            }
+
+            if ($has_expired) {
+                $errors->add('ofw_offer_expired', self::expired_notice_text());
+            }
+        }
+
+        /**
+         * Customer-facing copy. Centralized so the same wording appears in
+         * cart, checkout, and order-failed paths.
+         */
+        private static function expired_notice_text() {
+            return __(
+                'An accepted offer in your cart has expired and was removed. Please submit a new offer to complete this purchase.',
+                'offers-for-woocommerce'
+            );
+        }
+    }
+}

--- a/includes/class-ofw-offer-expiration.php
+++ b/includes/class-ofw-offer-expiration.php
@@ -13,9 +13,14 @@
  *   - Checkout validation produces a hard error if an expired offer somehow
  *     survives into the order-placement step.
  *
- * Expiration uses end-of-day semantics (23:59:59 in the site timezone) to stay
- * consistent with the legacy admin sweep and the email-link handler — a single
- * cut-off avoids merchants seeing different behavior in different code paths.
+ * Expiration honors what the admin chose in the "Offer Expires" field
+ * (stored as `Y-m-d H:i` in the site timezone):
+ *   - If a specific time was chosen, that exact minute is the cut-off.
+ *   - If no time was chosen (date-only or `00:00` midnight), the cut-off
+ *     is end-of-day so the offer remains valid for the calendar day the
+ *     customer was promised in the email.
+ * Earlier code paths always rolled forward to 23:59:59, silently extending
+ * time-specific offers by up to a day — this module replaces that.
  *
  * @package Angelleye_Offers_For_Woocommerce
  * @since   3.1.3
@@ -89,9 +94,13 @@ if (!class_exists('OFW_Offer_Expiration')) {
         }
 
         /**
-         * Site-local Unix timestamp at which the offer becomes invalid (inclusive
-         * of the calendar day stored in meta). False when the offer has no
-         * expiration set.
+         * Site-local Unix timestamp at which the offer becomes invalid. False
+         * when the offer has no expiration set.
+         *
+         * Admins can enter either a date or a date+time. A date-only entry
+         * (or an explicit midnight) extends the cut-off to end-of-day so
+         * the customer gets the full calendar day promised in the email.
+         * Any other time is honored exactly.
          *
          * @param int $offer_id
          * @return int|false
@@ -107,7 +116,12 @@ if (!class_exists('OFW_Offer_Expiration')) {
                 return false;
             }
 
-            return strtotime(date('Y-m-d 23:59:59', $parsed));
+            // Date-only input or midnight → expire at end of that calendar day.
+            if ((int) date('H', $parsed) === 0 && (int) date('i', $parsed) === 0 && (int) date('s', $parsed) === 0) {
+                return strtotime(date('Y-m-d 23:59:59', $parsed));
+            }
+
+            return $parsed;
         }
 
         /**
@@ -117,10 +131,8 @@ if (!class_exists('OFW_Offer_Expiration')) {
         public static function sweep_expired_offers() {
             global $wpdb;
 
-            $now_mysql = current_time('mysql');
-
-            $rows = $wpdb->get_results($wpdb->prepare(
-                "SELECT pm.post_id, pm.meta_value
+            $post_ids = $wpdb->get_col($wpdb->prepare(
+                "SELECT pm.post_id
                    FROM {$wpdb->postmeta} pm
                    INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
                   WHERE pm.meta_key = %s
@@ -130,29 +142,26 @@ if (!class_exists('OFW_Offer_Expiration')) {
                 self::META_KEY,
                 self::OFFER_POST_TYPE,
                 self::EXPIRED_STATUS
-            ), ARRAY_A);
+            ));
 
-            if (empty($rows)) {
+            if (empty($post_ids)) {
                 return;
             }
 
-            foreach ($rows as $row) {
-                $parsed = strtotime($row['meta_value']);
-                if (!$parsed) {
-                    continue;
-                }
-
-                $cutoff_mysql = date('Y-m-d 23:59:59', $parsed);
-                if ($cutoff_mysql > $now_mysql) {
+            // Delegate the cut-off rule to is_expired() so there is exactly
+            // one place that decides whether an offer has expired.
+            foreach ($post_ids as $post_id) {
+                $post_id = (int) $post_id;
+                if (!self::is_expired($post_id)) {
                     continue;
                 }
 
                 wp_update_post(array(
-                    'ID'          => (int) $row['post_id'],
+                    'ID'          => $post_id,
                     'post_status' => self::EXPIRED_STATUS,
                 ));
 
-                do_action('ofw_offer_expired', (int) $row['post_id']);
+                do_action('ofw_offer_expired', $post_id);
             }
         }
 

--- a/includes/class-ofw-offer-expiration.php
+++ b/includes/class-ofw-offer-expiration.php
@@ -14,13 +14,19 @@
  *     survives into the order-placement step.
  *
  * Expiration honors what the admin chose in the "Offer Expires" field
- * (stored as `Y-m-d H:i` in the site timezone):
+ * (stored as a naive `Y-m-d H:i` string the admin meant in site-local
+ * wall-clock time):
+ *   - Converted to GMT via WP core's get_gmt_from_date() so the result
+ *     is correct regardless of the server's PHP timezone (common
+ *     mismatch on managed hosting that runs PHP in UTC while the site
+ *     is configured for a regional timezone).
  *   - If a specific time was chosen, that exact minute is the cut-off.
  *   - If no time was chosen (date-only or `00:00` midnight), the cut-off
  *     is end-of-day so the offer remains valid for the calendar day the
  *     customer was promised in the email.
- * Earlier code paths always rolled forward to 23:59:59, silently extending
- * time-specific offers by up to a day — this module replaces that.
+ * Earlier code paths used `strtotime()` + `current_time('timestamp')`,
+ * which only happened to align when PHP's TZ matched the site's. This
+ * module makes the rule correct by construction.
  *
  * @package Angelleye_Offers_For_Woocommerce
  * @since   3.1.3
@@ -90,16 +96,24 @@ if (!class_exists('OFW_Offer_Expiration')) {
                 return false;
             }
 
-            return $cutoff <= current_time('timestamp', 0);
+            // Both sides are real (UTC) Unix timestamps, so the comparison
+            // is timezone-correct regardless of PHP's default timezone.
+            return $cutoff <= time();
         }
 
         /**
-         * Site-local Unix timestamp at which the offer becomes invalid. False
+         * Real (UTC) Unix timestamp at which the offer becomes invalid. False
          * when the offer has no expiration set.
          *
-         * Admins can enter either a date or a date+time. A date-only entry
-         * (or an explicit midnight) extends the cut-off to end-of-day so
-         * the customer gets the full calendar day promised in the email.
+         * The admin enters a naive `Y-m-d H:i` value in the "Offer Expires"
+         * field that they mean as site-local wall-clock time. We hand it to
+         * get_gmt_from_date() — the WP core helper that knows the site
+         * timezone (timezone_string or gmt_offset) — so the conversion is
+         * correct even when the server's PHP timezone differs from the
+         * WordPress one (common on managed hosting that runs PHP in UTC).
+         *
+         * A date-only entry or an explicit midnight is promoted to end-of-day
+         * so the customer gets the full calendar day promised in the email.
          * Any other time is honored exactly.
          *
          * @param int $offer_id
@@ -111,17 +125,55 @@ if (!class_exists('OFW_Offer_Expiration')) {
                 return false;
             }
 
-            $parsed = strtotime($raw);
-            if (!$parsed) {
+            $normalized = self::normalize_to_mysql(trim($raw));
+            if (!$normalized) {
                 return false;
             }
 
-            // Date-only input or midnight → expire at end of that calendar day.
-            if ((int) date('H', $parsed) === 0 && (int) date('i', $parsed) === 0 && (int) date('s', $parsed) === 0) {
-                return strtotime(date('Y-m-d 23:59:59', $parsed));
+            // Date-only or midnight → end of that calendar day in site TZ.
+            if (substr($normalized, 11) === '00:00:00') {
+                $normalized = substr($normalized, 0, 10) . ' 23:59:59';
             }
 
-            return $parsed;
+            // get_gmt_from_date() converts a site-local datetime string to
+            // its GMT equivalent. The trailing ' UTC' tells strtotime to read
+            // the result as UTC, yielding a real Unix timestamp.
+            $gmt_mysql = get_gmt_from_date($normalized, 'Y-m-d H:i:s');
+            $timestamp = strtotime($gmt_mysql . ' UTC');
+
+            return $timestamp ? $timestamp : false;
+        }
+
+        /**
+         * Coerce the stored value to a canonical `Y-m-d H:i:s` string so
+         * get_gmt_from_date() (which is regex-strict) accepts it.
+         *
+         * Returns false when the value doesn't look like a datetime at all.
+         *
+         * @param string $value
+         * @return string|false
+         */
+        private static function normalize_to_mysql($value) {
+            if (preg_match('/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})$/', $value)) {
+                return $value;
+            }
+            if (preg_match('/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2})$/', $value, $m)) {
+                return $m[1] . ' ' . $m[2] . ':00';
+            }
+            if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value)) {
+                return $value . ' 00:00:00';
+            }
+
+            // Fallback for legacy or unexpected formats: parse permissively
+            // with strtotime() and re-emit in canonical form. PHP's TZ here
+            // affects only the string-to-timestamp step; the resulting
+            // canonical string is what get_gmt_from_date() will then
+            // re-interpret in the site timezone.
+            $ts = strtotime($value);
+            if (!$ts) {
+                return false;
+            }
+            return gmdate('Y-m-d H:i:s', $ts);
         }
 
         /**

--- a/offers-for-woocommerce.php
+++ b/offers-for-woocommerce.php
@@ -83,6 +83,13 @@ require_once(plugin_dir_path(__FILE__) . 'includes/compatibility/class-ofw-compa
 add_action('plugins_loaded', array('OFW_Compatibility_Loader', 'load'), 20);
 
 /**
+ * Offer expiration enforcement (cron sweep + cart/checkout guards).
+ * Self-contained module — owns its own hook registration.
+ */
+require_once(plugin_dir_path(__FILE__) . 'includes/class-ofw-offer-expiration.php');
+OFW_Offer_Expiration::register();
+
+/**
  * Shared AngellEYE push-notifications class. Self-contained — copy the file as-is
  * into other AngellEYE plugins; the class_exists guard ensures only one copy loads.
  */
@@ -118,8 +125,10 @@ function angelleye_ofwc_load_plugin_textdomain() {
  * @since 0.1.0
  */
 register_activation_hook(__FILE__, array('Angelleye_Offers_For_Woocommerce', 'activate'));
+register_activation_hook(__FILE__, array('OFW_Offer_Expiration', 'activate'));
 
 register_deactivation_hook(__FILE__, array('Angelleye_Offers_For_Woocommerce', 'deactivate'));
+register_deactivation_hook(__FILE__, array('OFW_Offer_Expiration', 'deactivate'));
 
 /**
  * Plugins Loaded init

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -2148,12 +2148,6 @@ class Angelleye_Offers_For_Woocommerce {
             $offer_uid = get_post_meta($offer->ID, 'orig_offer_uid', true);
 
             /**
-             * Check offer expiration date.
-             */
-            $expiration_date = get_post_meta($offer->ID, 'offer_expiration_date', true);
-            $expiration_date_formatted = ($expiration_date) ? date("Y-m-d 23:59:59", strtotime($expiration_date)) : false;
-
-            /**
              * Invalid Offer Id
              */
             if ($offer == '') {
@@ -2165,11 +2159,10 @@ class Angelleye_Offers_For_Woocommerce {
 
                 error_log("1572");
                 $this->send_api_response(__('Invalid Offer Status or Expired Offer Id; See shop manager for assistance', 'offers-for-woocommerce'));
-            } elseif (($expiration_date_formatted) && ($expiration_date_formatted <= (date("Y-m-d H:i:s", current_time('timestamp', 0))) )) {
+            } elseif (class_exists('OFW_Offer_Expiration') && OFW_Offer_Expiration::is_expired($offer->ID)) {
                 /**
-                 * If offer counter 'offer_expiration_date' is past
+                 * Offer past its `offer_expiration_date` — central helper owns the rule.
                  */
-
                 $request_error = true;
                 $this->send_api_response(__('Offer has expired; You can submit a new offer using the form below.', 'offers-for-woocommerce'));
             } else {
@@ -2587,9 +2580,15 @@ class Angelleye_Offers_For_Woocommerce {
 
                     /**
                      * Error - Offer Not Accepted/Countered.
+                     *
+                     * Filter defaults to true here (matching the email-link handler) so
+                     * an offer that has been flipped to `expired-offer` status cannot slip
+                     * through checkout. The admin-created-open-offer callback at
+                     * ofw_not_allow_invalid_offer_status() returns false only for that
+                     * specific case, preserving its existing behavior.
                      */
                     if ($offer->post_status != 'accepted-offer' && $offer->post_status != 'countered-offer' && $offer->post_status != 'buyercountered-offer') {
-                        if (apply_filters('ofw_not_allow_invalid_offer_status', false, $offer)) {
+                        if (apply_filters('ofw_not_allow_invalid_offer_status', true, $offer)) {
                             error_log("1836");
                             $request_error = true;
                             $this->send_api_response(__('Invalid Offer Status or Expired Offer Id; See shop manager for assistance', 'offers-for-woocommerce'), '0');


### PR DESCRIPTION
Expired offers were still purchasable at the discounted price if a customer clicked an old email link or completed checkout after the offer expired. Two root causes:

1. Auto-expiration only ran when an admin opened the offers list screen, so post_status often stayed `accepted-offer` past the expiration date.
2. The cart/checkout flow trusted post_status alone and never re-checked `offer_expiration_date`. The `ofw_not_allow_invalid_ offer_status` filter at checkout also defaulted to false, silently suppressing the rejection even when status was `expired-offer`.

Changes:
- New OFW_Offer_Expiration module centralizes the expiration rule (is_expired / get_expiration_cutoff) and enforces it via:
  - Hourly WP-Cron sweep that flips past-date offers to `expired-offer` without depending on admin presence.
  - `woocommerce_check_cart_items` guard that removes expired offers from the cart on every cart/checkout render.
  - `woocommerce_after_checkout_validation` guard that adds a WP_Error so WC blocks order placement.
- Email-link handler now delegates to the shared helper instead of duplicating the date math inline.
- Flipped the `ofw_not_allow_invalid_offer_status` default at checkout from false to true, matching the email-link handler.
- Activation/deactivation hooks schedule and clear the cron event.

End-of-day (23:59:59) semantics preserved to match the legacy admin sweep and email-link behavior. The legacy admin sweep is left in place as a harmless fallback.