### PR TITLE
Fix: Make the offer-expiration date picker render consistently

### DIFF
--- a/admin/assets/js/admin.js
+++ b/admin/assets/js/admin.js
@@ -1,5 +1,19 @@
 (function ( $ ) {
     "use strict";
+
+    /**
+     * Capture xdsoft's $.fn.datetimepicker at script-load time and re-expose
+     * it under a plugin-scoped name. Other plugins or themes (notably the
+     * jQuery UI Timepicker Addon) also register $.fn.datetimepicker; whichever
+     * loads last wins, which previously caused a different — and broken —
+     * picker UI to appear on some sites. Calling our own alias guarantees the
+     * picker the plugin bundles is the one that opens, regardless of what
+     * else is on the page.
+     */
+    if (typeof $.fn.datetimepicker === 'function' && typeof $.fn.ofwDatetimepicker !== 'function') {
+        $.fn.ofwDatetimepicker = $.fn.datetimepicker;
+    }
+
     $(function () {
         let offer_price_per = document.getElementById('offer-price-per');
 
@@ -19,15 +33,21 @@
          * @since   1.0.1
          */
         var currentDate = new Date();
-        $('.datepicker').datetimepicker({
-            minDate: currentDate,
-            format: 'M d, Y H:i'
-        });
+        var $ofwDatepicker = $('.ofw-offer-expiration-datepicker');
+        if ($ofwDatepicker.length && typeof $.fn.ofwDatetimepicker === 'function') {
+            $ofwDatepicker.ofwDatetimepicker({
+                minDate: currentDate,
+                format: 'M d, Y H:i'
+            });
+        }
 
         var meta_box_offers_submit = document.getElementById('meta-box-offers-submit');
         if( undefined !== meta_box_offers_submit && meta_box_offers_submit !== null ){
             meta_box_offers_submit.addEventListener('click' ,function(){
-                var theDate = new Date(Date.parse(jQuery('.datepicker').datetimepicker('getValue')));
+                if (!$ofwDatepicker.length || typeof $.fn.ofwDatetimepicker !== 'function') {
+                    return;
+                }
+                var theDate = new Date(Date.parse($ofwDatepicker.ofwDatetimepicker('getValue')));
                 if (theDate === 'Invalid Date') {
                     offer_expiration_date.value = '';
                 }

--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -2892,15 +2892,18 @@ class Angelleye_Offers_For_Woocommerce_Admin {
             wp_enqueue_script('offers-for-woocommerce-angelleye-offers-jquery-confirm-min', plugins_url('assets/js/jquery.confirm.min.js', __FILE__), array('jquery'), Angelleye_Offers_For_Woocommerce::VERSION);
         }
         if ("woocommerce_offer" == $screen->id && is_admin()) {
-            // Jquery datepicker.js
-            wp_enqueue_script('jquery-ui');
-            wp_enqueue_script('jquery-ui-datepicker');
-            wp_enqueue_script('timepicker', plugins_url('assets/js/jquery.datetimepicker.full.min.js', __FILE__), array('jquery'), '1.2');
+            // xdsoft DateTimePicker — the picker the plugin ships and is
+            // tested against. Do NOT enqueue jquery-ui-datepicker here; it
+            // pulls in libraries (e.g. Trent Richardson's Timepicker Addon
+            // via other plugins) that also register $.fn.datetimepicker and
+            // override ours. admin.js depends on this handle so it is
+            // guaranteed to load first.
+            wp_enqueue_script('ofw-datetimepicker', plugins_url('assets/js/jquery.datetimepicker.full.min.js', __FILE__), array('jquery'), '1.2');
             // autoNumeric js
             wp_enqueue_script('offers-for-woocommerce-angelleye-offers-jquery-auto-numeric', plugins_url('../public/assets/js/autoNumeric.js', __FILE__), array('jquery'), Angelleye_Offers_For_Woocommerce::VERSION);
 
             // admin scripts
-            wp_enqueue_script('offers-for-woocommerce-admin-script', plugins_url('assets/js/admin.js', __FILE__), array('jquery'), Angelleye_Offers_For_Woocommerce::VERSION);
+            wp_enqueue_script('offers-for-woocommerce-admin-script', plugins_url('assets/js/admin.js', __FILE__), array('jquery', 'ofw-datetimepicker'), Angelleye_Offers_For_Woocommerce::VERSION);
             global $post, $wpdb;
             $ofw_offer_expiration_date_show = 'false';
             $expiration_date = get_post_meta($post->ID, 'offer_expiration_date', true);

--- a/admin/views/meta-panel-summary.php
+++ b/admin/views/meta-panel-summary.php
@@ -329,7 +329,7 @@
                         } else {
                             $expiry_date_formated = '';
                         } ?>
-                        <input type="text" name="offer_expiration_date" class="datepicker" id="offer-expiration-date" value="<?php echo $expiry_date_formated; ?>" autocomplete="off">
+                        <input type="text" name="offer_expiration_date" class="ofw-offer-expiration-datepicker" id="offer-expiration-date" value="<?php echo $expiry_date_formated; ?>" autocomplete="off">
                         <input type="hidden" name="offer_expiration_date_hidden" id="offer_expiration_date_hidden" value="" />
                     </div>
 


### PR DESCRIPTION
The "Offer Expires" admin field bound xdsoft's DateTimePicker via the generic `.datepicker` selector and the generic `$.fn.datetimepicker` method name. On sites that load Trent Richardson's jQuery UI Timepicker Addon (directly or via another plugin/theme), that library registered the same method name after ours and a localized, broken hour/minute picker appeared instead.

Changes:
- Renamed the input class to `.ofw-offer-expiration-datepicker` so no other library binds to our field.
- Captured `$.fn.datetimepicker` into `$.fn.ofwDatetimepicker` the moment xdsoft loads, so even if the global is overwritten later our picker still opens.
- Renamed the script handle to `ofw-datetimepicker` and declared it as a dependency of admin.js so load order is guaranteed.
- Dropped the no-op `wp_enqueue_script('jquery-ui')` and the unneeded `jquery-ui-datepicker` enqueue, which only invited the conflicting jQuery UI Timepicker Addon onto the page.