### PR TITLE
Add "Original Price" row to the Make Offer form

### DIFF
--- a/public/assets/js/public.js
+++ b/public/assets/js/public.js
@@ -95,11 +95,18 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 }
             });
 
-            $(".variations_form").on("show_variation", function () {
+            $(".variations_form").on("show_variation", function (event, variation) {
                 if ($('.single_add_to_cart_button').hasClass('disabled')) {
                     $('.single_offer_button').addClass('disabled');
                 } else {
                     $('.single_offer_button').removeClass('disabled');
+                }
+                // Refresh the Original Price display in the Make Offer form
+                // with the selected variation's price. WC builds price_html via
+                // the same filter chain Aelia / VillaTheme hook into, so the
+                // currency is correct without any plugin-specific code here.
+                if (variation && typeof variation.price_html !== 'undefined' && variation.price_html !== '') {
+                    $('.ofwc-original-price-value').html(variation.price_html);
                 }
             });
 

--- a/public/views/public.php
+++ b/public/views/public.php
@@ -151,6 +151,32 @@ if( !empty( $offer_single_use ) ) {
                     <input type="hidden" name="ofwc_minimum_offer_price" id="ofwc_minimum_offer_price" value="<?php echo $ofwc_minimum_offer_price; ?>">
                     <input type="hidden" name="ofwc_minimum_offer_price_type" id="ofwc_minimum_offer_price_type" value="<?php echo $ofwc_minimum_offer_price_type; ?>">
                     <input type="hidden" name="ofwc_hidden_price_type" id="ofwc_hidden_price_type" value="<?php echo $product_type; ?>">
+                <?php
+                /**
+                 * Original price row.
+                 *
+                 * $product->get_price_html() runs through WC's full price filter
+                 * chain (woocommerce_product_get_price, wc_price, etc.), so
+                 * Aelia Currency Switcher and VillaTheme Multi Currency — both
+                 * registered via includes/compatibility/ — produce a properly
+                 * converted display here automatically. No plugin-specific
+                 * branching needed.
+                 *
+                 * For variable products this shows the price range on initial
+                 * render; public.js refreshes the value on show_variation using
+                 * the variation object's price_html (also currency-filtered).
+                 */
+                $ofwc_original_price_html = ($product instanceof WC_Product) ? $product->get_price_html() : '';
+                $ofwc_original_price_html = apply_filters('aeofwc_offer_form_original_price_html', $ofwc_original_price_html, $product, $is_counter_offer);
+                if (!empty($ofwc_original_price_html)) :
+                ?>
+                <div class="woocommerce-make-offer-form-section ofwc-original-price-row">
+                    <div class="woocommerce-make-offer-form-part-full">
+                        <label class="woocommerce-make-offer-form-label"><?php echo apply_filters('aeofwc_offer_form_label_original_price', __('Original Price', 'offers-for-woocommerce'), $is_counter_offer); ?></label>
+                        <div class="ofwc-original-price-value"><?php echo $ofwc_original_price_html; ?></div>
+                    </div>
+                </div>
+                <?php endif; ?>
                 <div class="woocommerce-make-offer-form-section">
                     <?php if(isset($is_sold_individually) && $is_sold_individually ) { ?>
                         <input type="hidden" name="offer_quantity" id="woocommerce-make-offer-form-quantity" data-m-dec="0" data-l-zero="deny" data-a-form="false" required="required" value="1" />


### PR DESCRIPTION
Customers complete the offer form without seeing the product's listed price for reference. Add a read-only row above the Price Each input that shows the product's regular price.

- Renders $product->get_price_html(), which flows through WC's standard price filter chain (woocommerce_product_get_price, wc_price, woocommerce_currency_symbol). Aelia Currency Switcher and VillaTheme Multi Currency — the supported compatibility plugins — already hook into that chain, so the displayed price honors the customer's selected currency with no plugin-specific code.
- Variable products: initial render shows the price range; JS refreshes to the selected variation's price_html on the WC show_variation event.
- Wrapped in two filters (aeofwc_offer_form_label_original_price, aeofwc_offer_form_original_price_html) for theme/plugin override.
- Hidden automatically when get_price_html() is empty so price-on-request or zero-price products stay clean.