### PR TITLE
Normalize offer line item pricing in cart calculation

### DIFF
--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -2436,6 +2436,8 @@ class Angelleye_Offers_For_Woocommerce {
                  */
                 if (isset($value['woocommerce_offer_price_per']) && $value['woocommerce_offer_price_per'] != '') {
                     $value['data']->set_price($value['woocommerce_offer_price_per']);
+                    $value['data']->set_regular_price( $value['woocommerce_offer_price_per'] );
+                    $value['data']->set_sale_price( '' );
                     $woocommerce->cart->set_quantity($key, $value['woocommerce_offer_quantity'], false);
                 }
             }


### PR DESCRIPTION
## Summary

Normalizes pricing on accepted-offer line items during cart calculation. In addition to the existing `set_price()` call, we now also set `regular_price` to the accepted offer price and clear `sale_price` in `my_woocommerce_before_calculate_totals()`.

## Problem

Previously, only the active price was overridden for offer items:

```php
$value['data']->set_price($value['woocommerce_offer_price_per']);
```

This leaves the product's `regular_price` and `sale_price` untouched on the in-memory cart object. When the original product had a sale price (`sale_price < regular_price`), WooCommerce's `is_on_sale()` still returned `true`, so cart/checkout could render the offer line with a misleading strikethrough regular price and an "on sale" badge. Any code reading `get_regular_price()` / `get_sale_price()` (mini-cart widgets, order review, analytics) also showed the original catalog price instead of the offer price.

## Changes

```php
$value['data']->set_price($value['woocommerce_offer_price_per']);
$value['data']->set_regular_price( $value['woocommerce_offer_price_per'] );
$value['data']->set_sale_price( '' );
```

- Sets `regular_price` to the accepted offer price.
- Clears `sale_price` so `is_on_sale()` returns `false`.
- Eliminates leftover "on sale" strikethrough/badge styling on offer line items.
- Keeps `regular_price` / `sale_price` readers consistent with the offer price.

## Scope & Impact

- **In-memory only** — operates on the cloned `WC_Product` object within `woocommerce_before_calculate_totals`. No database writes; the catalog product, shop, and product pages are unaffected.
- **Totals unchanged** — cart totals were already driven by `set_price()`; this change is presentation/consistency only.
- **Heads-up:** any messaging that computes savings from regular vs. active price (e.g. "you saved X%") will no longer see a sale on offer lines, since regular now equals the offer price.

## Affected File

- `wp-content/plugins/offers-for-woocommerce/public/class-offers-for-woocommerce.php` — `my_woocommerce_before_calculate_totals()`

## Testing

- [ ] Add an offer item (whose product has a regular + sale price) to the cart and confirm the line shows only the offer price with no strikethrough/"sale" badge.
- [ ] Verify cart/checkout totals match the accepted offer price.
- [ ] Confirm non-offer items in the same cart still display their normal pricing/sale styling.
- [ ] Confirm no changes to the product's stored prices after checkout.
