### PR TITLE
Add global auto accept/decline setting

### DIFF
--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -2379,6 +2379,62 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         );
 
         add_settings_field(
+                'general_setting_global_auto_accept_enabled', // ID
+                __('Enable Global Auto Accept', 'offers-for-woocommerce'), // Title
+                array($this, 'offers_for_woocommerce_options_page_output_input_checkbox'), // Callback
+                'offers_for_woocommerce_general_settings', // Page
+                'general_settings', // Section
+                array(
+                    'option_name' => 'offers_for_woocommerce_options_general',
+                    'input_required' => FALSE,
+                    'input_label' => 'general_setting_global_auto_accept_enabled',
+                    'description' => __('Automatically accept qualifying offers on every product. This is only applied to products that do not have their own Auto Accept setting enabled.', 'offers-for-woocommerce'),
+                )
+        );
+
+        add_settings_field(
+                'general_setting_global_auto_accept_percentage', // ID
+                __('Global Auto Accept Percentage', 'offers-for-woocommerce'), // Title
+                array($this, 'offers_for_woocommerce_options_page_output_input_text'), // Callback
+                'offers_for_woocommerce_general_settings', // Page
+                'general_settings', // Section
+                array(
+                    'option_name' => 'offers_for_woocommerce_options_general',
+                    'input_required' => FALSE,
+                    'input_label' => 'general_setting_global_auto_accept_percentage',
+                    'description' => __('Offers at or above this percentage of the product price are accepted automatically. Enter a number from 1 to 100.', 'offers-for-woocommerce'),
+                )
+        );
+
+        add_settings_field(
+                'general_setting_global_auto_decline_enabled', // ID
+                __('Enable Global Auto Decline', 'offers-for-woocommerce'), // Title
+                array($this, 'offers_for_woocommerce_options_page_output_input_checkbox'), // Callback
+                'offers_for_woocommerce_general_settings', // Page
+                'general_settings', // Section
+                array(
+                    'option_name' => 'offers_for_woocommerce_options_general',
+                    'input_required' => FALSE,
+                    'input_label' => 'general_setting_global_auto_decline_enabled',
+                    'description' => __('Automatically decline qualifying offers on every product. This is only applied to products that do not have their own Auto Decline setting enabled.', 'offers-for-woocommerce'),
+                )
+        );
+
+        add_settings_field(
+                'general_setting_global_auto_decline_percentage', // ID
+                __('Global Auto Decline Percentage', 'offers-for-woocommerce'), // Title
+                array($this, 'offers_for_woocommerce_options_page_output_input_text'), // Callback
+                'offers_for_woocommerce_general_settings', // Page
+                'general_settings', // Section
+                array(
+                    'option_name' => 'offers_for_woocommerce_options_general',
+                    'input_required' => FALSE,
+                    'input_label' => 'general_setting_global_auto_decline_percentage',
+                    'description' => __('Offers at or below this percentage of the product price are declined automatically. Enter a number from 1 to 100.', 'offers-for-woocommerce'),
+                )
+        );
+
+        add_settings_field(
                 'general_setting_disabled_make_offer_on_product_sale', // ID
                 __('Disable for Sale Items', 'offers-for-woocommerce'), // Title
                 array($this, 'offers_for_woocommerce_options_page_output_input_checkbox'), // Callback TEXT input

--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -731,6 +731,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         update_post_meta($post_id, '_offers_for_woocommerce_auto_decline_enabled', !empty($_POST['_offers_for_woocommerce_auto_decline_enabled']) ? 'yes' : 'no' );
         update_post_meta($post_id, '_offers_for_woocommerce_auto_accept_percentage', !empty($_POST['_offers_for_woocommerce_auto_accept_percentage']) ? wc_clean($_POST['_offers_for_woocommerce_auto_accept_percentage']) : '' );
         update_post_meta($post_id, '_offers_for_woocommerce_auto_decline_percentage', !empty($_POST['_offers_for_woocommerce_auto_decline_percentage']) ? wc_clean($_POST['_offers_for_woocommerce_auto_decline_percentage']) : '' );
+        update_post_meta($post_id, '_offers_for_woocommerce_ignore_global_auto_settings', !empty($_POST['_offers_for_woocommerce_ignore_global_auto_settings']) ? 'yes' : 'no' );
     }
 
     /**
@@ -798,6 +799,12 @@ class Angelleye_Offers_For_Woocommerce_Admin {
         $field_callback_auto_decline_enabled = ($post_meta_auto_decline_enabled) ?: 'no';
         $post_meta_auto_decline_percentage = get_post_meta($post->ID, '_offers_for_woocommerce_auto_decline_percentage', true);
         $post_meta_auto_decline_percentage_value = (!empty($post_meta_auto_decline_percentage)) ? $post_meta_auto_decline_percentage : '';
+
+        /**
+         * Ignore global auto accept/decline settings for this product
+         */
+        $post_meta_ignore_global_auto_settings = get_post_meta($post->ID, '_offers_for_woocommerce_ignore_global_auto_settings', true);
+        $field_callback_ignore_global_auto_settings = ($post_meta_ignore_global_auto_settings) ?: 'no';
         ?>
         <div id="custom_tab_data_offers_for_woocommerce" class="panel woocommerce_options_panel">
             <div class="options_group">
@@ -813,6 +820,9 @@ class Angelleye_Offers_For_Woocommerce_Admin {
             <div class="options_group">
                 <?php woocommerce_wp_checkbox(array('value' => $field_value_auto_decline_enabled, 'cbvalue' => $field_callback_auto_decline_enabled, 'id' => '_offers_for_woocommerce_auto_decline_enabled', 'label' => __('Enable Auto Decline Offers?', 'offers-for-woocommerce'), 'desc_tip' => 'true', 'description' => __('Enable this option to automatically decline offers based on the percentage set.', 'offers-for-woocommerce'))); ?>
                 <p class="form-field offers_for_woocommerce_auto_decline_percentage "><label for="offers_for_woocommerce_auto_decline_percentage"><?php echo __('Auto Decline Percentage', 'offers-for-woocommerce'); ?></label><input type="number" placeholder="<?php echo __('Enter Percentage', 'offers-for-woocommerce'); ?>" value="<?php echo $post_meta_auto_decline_percentage_value; ?>" min="1" max="100" id="offers_for_woocommerce_auto_decline_percentage" name="_offers_for_woocommerce_auto_decline_percentage" style="" class="short"> <?php echo '<img class="help_tip" data-tip="' . esc_attr('Any offer below the percentage entered here will be automatically declined.') . '" src="' . esc_url(WC()->plugin_url()) . '/assets/images/help.png" height="16" width="16" />'; ?> </p>
+            </div>
+            <div class="options_group">
+                <?php woocommerce_wp_checkbox(array('value' => 'yes', 'cbvalue' => $field_callback_ignore_global_auto_settings, 'id' => '_offers_for_woocommerce_ignore_global_auto_settings', 'label' => __('Ignore Global Auto Accept/Decline?', 'offers-for-woocommerce'), 'desc_tip' => 'true', 'description' => __('Enable this option to exclude this product from the store-wide Global Auto Accept and Global Auto Decline settings. The product-level options above still apply.', 'offers-for-woocommerce'))); ?>
             </div>
             <?php do_action('aeofw_offers_tab_options', $post->ID, $post); ?>
         </div>

--- a/offers-for-woocommerce.php
+++ b/offers-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Plugin Name:       Offers for WooCommerce
  * Plugin URI:        http://www.angelleye.com/product/offers-for-woocommerce
  * Description:       Accept offers for products on your website.  Respond with accept, deny, or counter-offer, and manage all active offers/counters easily.
- * Version:           3.1.2
+ * Version:           3.1.2.1
  * Author:            Angell EYE
  * Author URI:        http://www.angelleye.com/
  * License:           GNU General Public License v3.0

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -2944,6 +2944,9 @@ class Angelleye_Offers_For_Woocommerce {
         if ($enabled === 'yes') {
             return $enabled; // Product-level setting present - respect it.
         }
+        if ($this->ofw_product_ignores_global_auto_settings($product_id)) {
+            return $enabled; // Product opted out of the global settings.
+        }
         $settings = ofwc_get_general_settings();
         return !empty($settings['general_setting_global_auto_accept_enabled']) ? 'yes' : $enabled;
     }
@@ -2966,6 +2969,9 @@ class Angelleye_Offers_For_Woocommerce {
         $product_enabled = get_post_meta($product_id, '_offers_for_woocommerce_auto_accept_enabled', true);
         if ($product_enabled === 'yes') {
             return $percentage; // Product-level setting present - use its percentage.
+        }
+        if ($this->ofw_product_ignores_global_auto_settings($product_id)) {
+            return $percentage; // Product opted out of the global settings.
         }
         $settings = ofwc_get_general_settings();
         if (!empty($settings['general_setting_global_auto_accept_enabled'])
@@ -2993,6 +2999,9 @@ class Angelleye_Offers_For_Woocommerce {
         if ($enabled === 'yes') {
             return $enabled; // Product-level setting present - respect it.
         }
+        if ($this->ofw_product_ignores_global_auto_settings($product_id)) {
+            return $enabled; // Product opted out of the global settings.
+        }
         $settings = ofwc_get_general_settings();
         return !empty($settings['general_setting_global_auto_decline_enabled']) ? 'yes' : $enabled;
     }
@@ -3015,6 +3024,9 @@ class Angelleye_Offers_For_Woocommerce {
         if ($product_enabled === 'yes') {
             return $percentage; // Product-level setting present - use its percentage.
         }
+        if ($this->ofw_product_ignores_global_auto_settings($product_id)) {
+            return $percentage; // Product opted out of the global settings.
+        }
         $settings = ofwc_get_general_settings();
         if (!empty($settings['general_setting_global_auto_decline_enabled'])
             && isset($settings['general_setting_global_auto_decline_percentage'])
@@ -3022,6 +3034,19 @@ class Angelleye_Offers_For_Woocommerce {
             return $settings['general_setting_global_auto_decline_percentage'];
         }
         return $percentage;
+    }
+
+    /**
+     * Whether a product is excluded from the store-wide global auto
+     * accept/decline settings via its per-product "Ignore Global Auto
+     * Accept/Decline" option.
+     *
+     * @param int $product_id Product ID.
+     *
+     * @return bool
+     */
+    public function ofw_product_ignores_global_auto_settings($product_id) {
+        return get_post_meta($product_id, '_offers_for_woocommerce_ignore_global_auto_settings', true) === 'yes';
     }
 
     /**

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -24,7 +24,7 @@ class Angelleye_Offers_For_Woocommerce {
      *
      * @var string
      */
-    const VERSION = '3.1.2';
+    const VERSION = '3.1.2.1';
 
     /**
      * Unique pluginidentifier
@@ -153,6 +153,17 @@ class Angelleye_Offers_For_Woocommerce {
              */
             add_action('woocommerce_before_checkout_process', array($this, 'ae_ofwc_woocommerce_before_checkout_process'));
             add_action('auto_accept_auto_decline_handler', array($this, 'ofwc_auto_accept_auto_decline_handler'), 10, 4);
+
+            /**
+             * Global auto accept/decline fallback.
+             * Applies the store-wide setting only when a product has no
+             * product-level auto accept/decline configured.
+             */
+            add_filter('aeofw_auto_accept_enabled', array($this, 'ofw_global_auto_accept_enabled'), 10, 4);
+            add_filter('aeofw_auto_accept_percentage', array($this, 'ofw_global_auto_accept_percentage'), 10, 4);
+            add_filter('aeofw_auto_decline_enabled', array($this, 'ofw_global_auto_decline_enabled'), 10, 4);
+            add_filter('aeofw_auto_decline_percentage', array($this, 'ofw_global_auto_decline_percentage'), 10, 4);
+
             add_action('init', array($this, 'ofw_create_required_files'), 0);
             add_action('woocommerce_make_offer_form_end', array($this, 'woocommerce_make_offer_form_end_own'), 10, 1);
             add_action('woocommerce_after_offer_submit', array($this, 'ofw_mailing_list_handler'), 10, 2);
@@ -1951,8 +1962,19 @@ class Angelleye_Offers_For_Woocommerce {
                 $user_offer_percentage = $productData['user_offer_percentage'];
                 $product_url = $productData['product_url'];
                 $offer_uid = $productData['offer_uid'];
+
+                /**
+                 * Respect the same auto decline filters used in
+                 * ofwc_auto_accept_auto_decline_handler() so that when auto
+                 * decline is forced globally the admin "new offer" email is
+                 * suppressed too.
+                 */
+                $post_meta_auto_decline_enabled = get_post_meta($product_id, '_offers_for_woocommerce_auto_decline_enabled', true);
+                $post_meta_auto_decline_enabled = apply_filters('aeofw_auto_decline_enabled', $post_meta_auto_decline_enabled, $product_id, $variant_id, $offer_id);
+
                 if (isset($post_meta_auto_decline_enabled) && $post_meta_auto_decline_enabled == 'yes') {
                     $auto_decline_percentage = get_post_meta($product_id, '_offers_for_woocommerce_auto_decline_percentage', true);
+                    $auto_decline_percentage = apply_filters('aeofw_auto_decline_percentage', $auto_decline_percentage, $product_id, $variant_id, $offer_id);
                     if (isset($offer_price) && !empty($offer_price) && isset($auto_decline_percentage) && !empty($auto_decline_percentage)) {
                         if ((int) $auto_decline_percentage >= (int) $user_offer_percentage) {
                             $offer_is_auto_decline = 'yes';
@@ -2815,6 +2837,27 @@ class Angelleye_Offers_For_Woocommerce {
     public function ofwc_auto_accept_auto_decline_handler($offer_id, $product_id, $variant_id, $emails) {
         $post_meta_auto_accept_enabled = get_post_meta($product_id, '_offers_for_woocommerce_auto_accept_enabled', true);
         $post_meta_auto_decline_enabled = get_post_meta($product_id, '_offers_for_woocommerce_auto_decline_enabled', true);
+
+        /**
+         * Filters to force auto accept/decline regardless of the per-product setting.
+         *
+         * Return the string 'yes' to enable (or '' / anything else to leave disabled).
+         * These make it possible to apply auto accept/decline to every product at
+         * once - including products added in the future - without toggling each one.
+         *
+         * Example - auto accept/decline on all products:
+         *   add_filter( 'aeofw_auto_accept_enabled', '__return_yes_string' );  // see note below
+         *
+         * @param string $enabled     Current value ('yes' when enabled on the product).
+         * @param int    $product_id  Product ID the offer was made on.
+         * @param int    $variant_id  Variation ID (0 when not a variation).
+         * @param int    $offer_id    Offer post ID.
+         *
+         * @since 1.2.0
+         */
+        $post_meta_auto_accept_enabled  = apply_filters('aeofw_auto_accept_enabled', $post_meta_auto_accept_enabled, $product_id, $variant_id, $offer_id);
+        $post_meta_auto_decline_enabled = apply_filters('aeofw_auto_decline_enabled', $post_meta_auto_decline_enabled, $product_id, $variant_id, $offer_id);
+
         $productData = $this->ofwc_get_product_detail($offer_id, $product_id, $variant_id);
         $offer_price = $productData['offer_price'];
         $user_offer_percentage = $productData['user_offer_percentage'];
@@ -2824,6 +2867,20 @@ class Angelleye_Offers_For_Woocommerce {
         if (isset($post_meta_auto_accept_enabled) && $post_meta_auto_accept_enabled === 'yes') {
 
             $auto_accept_percentage = get_post_meta($product_id, '_offers_for_woocommerce_auto_accept_percentage', true);
+
+            /**
+             * Filter the auto accept threshold percentage. Combined with
+             * 'aeofw_auto_accept_enabled' this lets a global default be set for
+             * every product. Offers at or above this percentage of the price are
+             * accepted automatically.
+             *
+             * @param string|int $auto_accept_percentage Current threshold.
+             * @param int        $product_id             Product ID.
+             * @param int        $variant_id             Variation ID (0 when none).
+             * @param int        $offer_id               Offer post ID.
+             */
+            $auto_accept_percentage = apply_filters('aeofw_auto_accept_percentage', $auto_accept_percentage, $product_id, $variant_id, $offer_id);
+
             if (isset($offer_price) && !empty($offer_price) && isset($auto_accept_percentage) && !empty($auto_accept_percentage)) {
 
                 if ((int) $auto_accept_percentage <= (int) $user_offer_percentage) {
@@ -2843,6 +2900,20 @@ class Angelleye_Offers_For_Woocommerce {
         if (isset($post_meta_auto_decline_enabled) && $post_meta_auto_decline_enabled === 'yes') {
 
             $auto_decline_percentage = get_post_meta($product_id, '_offers_for_woocommerce_auto_decline_percentage', true);
+
+            /**
+             * Filter the auto decline threshold percentage. Combined with
+             * 'aeofw_auto_decline_enabled' this lets a global default be set for
+             * every product. Offers at or below this percentage of the price are
+             * declined automatically.
+             *
+             * @param string|int $auto_decline_percentage Current threshold.
+             * @param int        $product_id              Product ID.
+             * @param int        $variant_id              Variation ID (0 when none).
+             * @param int        $offer_id                Offer post ID.
+             */
+            $auto_decline_percentage = apply_filters('aeofw_auto_decline_percentage', $auto_decline_percentage, $product_id, $variant_id, $offer_id);
+
             if (isset($offer_price) && !empty($offer_price) && isset($auto_decline_percentage) && !empty($auto_decline_percentage)) {
                 if ((int) $auto_decline_percentage >= (int) $user_offer_percentage) {
                     do_action('ofw_before_auto_decline_offer', $offer_id, $product_id, $variant_id, $emails);
@@ -2853,6 +2924,104 @@ class Angelleye_Offers_For_Woocommerce {
             }
         }
 	    return null;
+    }
+
+    /**
+     * Global auto accept - enabled fallback.
+     *
+     * Applies the store-wide "Enable Global Auto Accept" setting only when the
+     * product itself has NOT enabled auto accept. A product-level setting always
+     * takes precedence over the global default.
+     *
+     * @param string $enabled    Per-product value ('yes' when enabled on the product).
+     * @param int    $product_id Product ID.
+     * @param int    $variant_id Variation ID (0 when none).
+     * @param int    $offer_id   Offer post ID.
+     *
+     * @return string 'yes' when auto accept should run, otherwise the original value.
+     */
+    public function ofw_global_auto_accept_enabled($enabled, $product_id, $variant_id, $offer_id) {
+        if ($enabled === 'yes') {
+            return $enabled; // Product-level setting present - respect it.
+        }
+        $settings = ofwc_get_general_settings();
+        return !empty($settings['general_setting_global_auto_accept_enabled']) ? 'yes' : $enabled;
+    }
+
+    /**
+     * Global auto accept - percentage fallback.
+     *
+     * Supplies the store-wide auto accept percentage when the product itself has
+     * not enabled auto accept. When the product has its own auto accept enabled,
+     * its percentage is used unchanged.
+     *
+     * @param string|int $percentage Per-product percentage.
+     * @param int        $product_id Product ID.
+     * @param int        $variant_id Variation ID (0 when none).
+     * @param int        $offer_id   Offer post ID.
+     *
+     * @return string|int
+     */
+    public function ofw_global_auto_accept_percentage($percentage, $product_id, $variant_id, $offer_id) {
+        $product_enabled = get_post_meta($product_id, '_offers_for_woocommerce_auto_accept_enabled', true);
+        if ($product_enabled === 'yes') {
+            return $percentage; // Product-level setting present - use its percentage.
+        }
+        $settings = ofwc_get_general_settings();
+        if (!empty($settings['general_setting_global_auto_accept_enabled'])
+            && isset($settings['general_setting_global_auto_accept_percentage'])
+            && $settings['general_setting_global_auto_accept_percentage'] !== '') {
+            return $settings['general_setting_global_auto_accept_percentage'];
+        }
+        return $percentage;
+    }
+
+    /**
+     * Global auto decline - enabled fallback.
+     *
+     * Applies the store-wide "Enable Global Auto Decline" setting only when the
+     * product itself has NOT enabled auto decline.
+     *
+     * @param string $enabled    Per-product value ('yes' when enabled on the product).
+     * @param int    $product_id Product ID.
+     * @param int    $variant_id Variation ID (0 when none).
+     * @param int    $offer_id   Offer post ID.
+     *
+     * @return string 'yes' when auto decline should run, otherwise the original value.
+     */
+    public function ofw_global_auto_decline_enabled($enabled, $product_id, $variant_id, $offer_id) {
+        if ($enabled === 'yes') {
+            return $enabled; // Product-level setting present - respect it.
+        }
+        $settings = ofwc_get_general_settings();
+        return !empty($settings['general_setting_global_auto_decline_enabled']) ? 'yes' : $enabled;
+    }
+
+    /**
+     * Global auto decline - percentage fallback.
+     *
+     * Supplies the store-wide auto decline percentage when the product itself has
+     * not enabled auto decline.
+     *
+     * @param string|int $percentage Per-product percentage.
+     * @param int        $product_id Product ID.
+     * @param int        $variant_id Variation ID (0 when none).
+     * @param int        $offer_id   Offer post ID.
+     *
+     * @return string|int
+     */
+    public function ofw_global_auto_decline_percentage($percentage, $product_id, $variant_id, $offer_id) {
+        $product_enabled = get_post_meta($product_id, '_offers_for_woocommerce_auto_decline_enabled', true);
+        if ($product_enabled === 'yes') {
+            return $percentage; // Product-level setting present - use its percentage.
+        }
+        $settings = ofwc_get_general_settings();
+        if (!empty($settings['general_setting_global_auto_decline_enabled'])
+            && isset($settings['general_setting_global_auto_decline_percentage'])
+            && $settings['general_setting_global_auto_decline_percentage'] !== '') {
+            return $settings['general_setting_global_auto_decline_percentage'];
+        }
+        return $percentage;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a store-wide way to auto accept / auto decline offers so merchants no longer have to toggle it on every product individually, plus a per-product override to exclude specific products.

### Global settings (Settings → Offers for WooCommerce → General)
Four new fields:
- **Enable Global Auto Accept** + **Global Auto Accept Percentage**
- **Enable Global Auto Decline** + **Global Auto Decline Percentage**

### Per-product opt-out (product Offers panel)
- New **"Ignore Global Auto Accept/Decline?"** checkbox, stored in `_offers_for_woocommerce_ignore_global_auto_settings`.
- When enabled, the product is excluded from both global settings while its own product-level auto accept/decline options still apply.

### Precedence (evaluated per action, accept and decline independently)
1. Product has that action enabled at the product level → its own setting and percentage win.
2. Product has the "Ignore Global" option checked → global is skipped, no auto action.
3. Otherwise → the global setting/percentage applies — including products added in the future, with no bulk re-run needed.

### Filters
The behavior is driven by new filters, which also allow per-product overrides in code:
- `aeofw_auto_accept_enabled` / `aeofw_auto_accept_percentage`
- `aeofw_auto_decline_enabled` / `aeofw_auto_decline_percentage`

Each receives `$product_id, $variant_id, $offer_id`.

### Other
- Fixes the admin email suppression check in `new_offer_form_submit()` to read the auto decline meta, keeping it consistent with the accept/decline handler.
- Bumps version to 3.1.5 (merged latest `release`) and adds a changelog entry.

## Testing
- `php -l` passes on all modified files.
- Product with no per-product config picks up the global setting; product with its own Auto Accept/Decline enabled keeps its own values; product with "Ignore Global" checked is excluded from the global setting.