### PR TITLE
Auto-accept: no cart redirect; clarify global setting labels

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -120,6 +120,7 @@ Automatic updates should work great for you.  As always, though, we recommend ba
 
 = 3.1.6 =
 * Tweak - Auto-accepted offers no longer redirect the buyer to the cart; the offer is accepted and the buyer receives the standard acceptance email, matching the manual-accept flow. (Legacy add-to-cart behavior can be restored via the aeofw_auto_accept_add_to_cart_redirect filter.) ([#535](https://github.com/angelleye/offers-for-woocommerce/pull/535))
+* Tweak - Clarified the Global Auto Accept and Global Auto Decline percentage field descriptions with worked examples so the thresholds (percentage of the product price) are easy to set correctly. ([#535](https://github.com/angelleye/offers-for-woocommerce/pull/535))
 
 = 3.1.5 - 07.08.2026 =
 * Feature - Added store-wide Global Auto Accept and Global Auto Decline settings (with percentages) on the General settings tab, applied automatically to products that do not have their own auto accept/decline configured. Includes a per-product "Ignore Global Auto Accept/Decline" option to exclude individual products. ([#534](https://github.com/angelleye/offers-for-woocommerce/pull/534))

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: woocommerce, offers, negotiation
 Requires at least: 5.5
 Tested up to: 7.0
-Stable tag: 3.1.5
+Stable tag: 3.1.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -117,6 +117,9 @@ Automatic updates should work great for you.  As always, though, we recommend ba
 * [Additional Plugin Tools](https://www.angelleye.com/offers-for-woocommerce-user-guide/#section-6)
 
 == Changelog ==
+
+= 3.1.6 =
+* Tweak - Auto-accepted offers no longer redirect the buyer to the cart; the offer is accepted and the buyer receives the standard acceptance email, matching the manual-accept flow. (Legacy add-to-cart behavior can be restored via the aeofw_auto_accept_add_to_cart_redirect filter.) ([#535](https://github.com/angelleye/offers-for-woocommerce/pull/535))
 
 = 3.1.5 - 07.08.2026 =
 * Feature - Added store-wide Global Auto Accept and Global Auto Decline settings (with percentages) on the General settings tab, applied automatically to products that do not have their own auto accept/decline configured. Includes a per-product "Ignore Global Auto Accept/Decline" option to exclude individual products. ([#534](https://github.com/angelleye/offers-for-woocommerce/pull/534))

--- a/admin/class-offers-for-woocommerce-admin.php
+++ b/admin/class-offers-for-woocommerce-admin.php
@@ -2411,7 +2411,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
                     'option_name' => 'offers_for_woocommerce_options_general',
                     'input_required' => FALSE,
                     'input_label' => 'general_setting_global_auto_accept_percentage',
-                    'description' => __('Offers at or above this percentage of the product price are accepted automatically. Enter a number from 1 to 100.', 'offers-for-woocommerce'),
+                    'description' => __('Enter the offer amount as a percentage of the product price. Offers at or above this percentage are accepted automatically. Example: 90 automatically accepts any offer that is 90% of the price or more (up to 10% off) &mdash; so on a $100 product, offers of $90 or more are accepted. Enter a number from 1 to 100.', 'offers-for-woocommerce'),
                 )
         );
 
@@ -2439,7 +2439,7 @@ class Angelleye_Offers_For_Woocommerce_Admin {
                     'option_name' => 'offers_for_woocommerce_options_general',
                     'input_required' => FALSE,
                     'input_label' => 'general_setting_global_auto_decline_percentage',
-                    'description' => __('Offers at or below this percentage of the product price are declined automatically. Enter a number from 1 to 100.', 'offers-for-woocommerce'),
+                    'description' => __('Enter the offer amount as a percentage of the product price. Offers at or below this percentage are declined automatically. Example: 70 automatically declines any offer that is 70% of the price or less (more than 30% off) &mdash; so on a $100 product, offers of $70 or less are declined. Enter a number from 1 to 100.', 'offers-for-woocommerce'),
                 )
         );
 

--- a/offers-for-woocommerce.php
+++ b/offers-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Plugin Name:       Offers for WooCommerce
  * Plugin URI:        http://www.angelleye.com/product/offers-for-woocommerce
  * Description:       Accept offers for products on your website.  Respond with accept, deny, or counter-offer, and manage all active offers/counters easily.
- * Version:           3.1.5
+ * Version:           3.1.6
  * Author:            Angell EYE
  * Author URI:        http://www.angelleye.com/
  * License:           GNU General Public License v3.0

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -24,7 +24,7 @@ class Angelleye_Offers_For_Woocommerce {
      *
      * @var string
      */
-    const VERSION = '3.1.5';
+    const VERSION = '3.1.6';
 
     /**
      * Unique pluginidentifier
@@ -2988,11 +2988,36 @@ class Angelleye_Offers_For_Woocommerce {
                     do_action('ofw_before_auto_approve_offer', $offer_id, $product_id, $variant_id, $emails);
                     $this->ofw_auto_approve_offer($offer_id, $emails );
                     do_action('ofw_after_auto_approve_offer', $offer_id, $product_id, $variant_id, $emails);
-                    $link_insert = ( strpos($product_url, '?') ) ? '&' : '?';
-                    $redirect = $product_url . $link_insert . '__aewcoapi=1&woocommerce-offer-id=' . $offer_id . '&woocommerce-offer-uid=' . $offer_uid;
-                    echo json_encode(array("statusmsg" => 'accepted-offer', 'redirect' => $redirect));
-                    exit;
-                    //return true;
+
+                    /**
+                     * By default an auto-accepted offer does NOT redirect the buyer
+                     * to add the item to the cart. The offer is marked accepted and
+                     * the buyer is sent the standard "Accepted Offer" email (handled
+                     * by ofw_auto_approve_offer() above), matching the manual-accept
+                     * flow - the buyer simply receives their confirmation email.
+                     *
+                     * Return true from this filter to restore the legacy behavior of
+                     * immediately redirecting the buyer to the cart with the accepted
+                     * offer applied.
+                     *
+                     * @param bool $redirect_to_cart Whether to redirect to the cart.
+                     * @param int  $offer_id         Offer post ID.
+                     * @param int  $product_id       Product ID.
+                     * @param int  $variant_id       Variation ID (0 when none).
+                     */
+                    if (apply_filters('aeofw_auto_accept_add_to_cart_redirect', false, $offer_id, $product_id, $variant_id)) {
+                        $link_insert = ( strpos($product_url, '?') ) ? '&' : '?';
+                        $redirect = $product_url . $link_insert . '__aewcoapi=1&woocommerce-offer-id=' . $offer_id . '&woocommerce-offer-uid=' . $offer_uid;
+                        echo json_encode(array("statusmsg" => 'accepted-offer', 'redirect' => $redirect));
+                        exit;
+                    }
+
+                    /**
+                     * Fall through so new_offer_form_submit() sends the standard
+                     * 'success' response and the buyer sees the normal
+                     * "offer submitted" confirmation (no cart redirect).
+                     */
+                    return;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Follow-up to #534. The auto accept/decline percentages keep their existing **"percentage of price"** meaning — accept when the offer is at or above the accept %, decline when it is at or below the decline %. No semantics change, no data migration.

Two changes:

1. **Auto-accepted offers no longer redirect the buyer to the cart.** The offer is marked accepted and the buyer receives the standard **Accepted Offer** email, matching the manual-accept flow. Legacy behavior can be restored with:
   ```php
   add_filter( 'aeofw_auto_accept_add_to_cart_redirect', '__return_true' );
   ```

2. **Clearer global setting descriptions.** The Global Auto Accept / Auto Decline percentage fields now include worked dollar examples so the "percentage of price" thresholds are easy to set correctly (e.g. "90 = accept offers of $90 or more on a $100 product").

## Testing
- `php -l` clean.
- Verified on a live install with a product set to accept ≥90% of price / decline ≤20% of price: 97% → accepted (no cart redirect), 67% → pending, 17% → declined.

Version bumped to 3.1.6 (3.1.5 is already tagged).