### PR TITLE
Base auto accept/decline on the live filtered product price

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -119,6 +119,7 @@ Automatic updates should work great for you.  As always, though, we recommend ba
 == Changelog ==
 
 = 3.1.6 - 07.09.2026 =
+* Fix - Auto accept/decline now measures the offer against the live, filtered product price (via woocommerce_product_get_price) instead of the price stored in the product settings, so decisions respect dynamic pricing plugins such as scheduled price decay and category discounts. ([#535](https://github.com/angelleye/offers-for-woocommerce/pull/535))
 * Tweak - Auto-accepted offers no longer redirect the buyer to the cart; the offer is accepted and the buyer receives the standard acceptance email, matching the manual-accept flow. (Legacy add-to-cart behavior can be restored via the aeofw_auto_accept_add_to_cart_redirect filter.) ([#535](https://github.com/angelleye/offers-for-woocommerce/pull/535))
 * Tweak - Clarified the Global Auto Accept and Global Auto Decline percentage field descriptions with worked examples so the thresholds (percentage of the product price) are easy to set correctly. ([#535](https://github.com/angelleye/offers-for-woocommerce/pull/535))
 

--- a/public/class-offers-for-woocommerce.php
+++ b/public/class-offers-for-woocommerce.php
@@ -3823,24 +3823,52 @@ class Angelleye_Offers_For_Woocommerce {
     public function ofwc_get_product_detail($offer_id, $product_id, $variant_id) {
 
         $productData = array();
-        if (isset($variant_id) && !empty($variant_id)) {
-            $variable_product = new WC_Product_Variation($variant_id);
-            $actual_regular_price = (isset($variable_product->regular_price) && !empty($variable_product->regular_price) ) ? $variable_product->regular_price : 0;
-            $actual_sales_price = $variable_product->sale_price;
-        } else {
-            $actual_regular_price = get_post_meta($product_id, '_regular_price', true);
-            $actual_sales_price = get_post_meta($product_id, '_sale_price', true);
-            $actual_regular_price = (isset($actual_regular_price) && !empty($actual_regular_price) ) ? $actual_regular_price : 0;
+
+        $product = ( $variant_id ) ? wc_get_product($variant_id) : wc_get_product($product_id);
+
+        /**
+         * Base the auto accept/decline decision on the live, filtered price.
+         * get_price() runs the woocommerce_product_get_price (and, for
+         * variations, woocommerce_product_variation_get_price) filter, so
+         * dynamic pricing plugins - scheduled price decay, category discounts,
+         * etc. - are respected and the decision matches the price the buyer
+         * actually saw. The accepted offer price still wins at checkout via the
+         * separate cart/checkout handling.
+         */
+        $product_price = ( $product ) ? (float) $product->get_price() : 0;
+
+        /**
+         * Fall back to the price stored in the product settings when the active
+         * price is unavailable (e.g. price-on-request products whose get_price()
+         * is empty), preserving the previous behavior in that case.
+         */
+        if ($product_price <= 0) {
+            if ($variant_id && $product) {
+                $product_price = (float) $product->get_regular_price();
+            } else {
+                $actual_regular_price = get_post_meta($product_id, '_regular_price', true);
+                $actual_sales_price = get_post_meta($product_id, '_sale_price', true);
+                $product_price = (!empty($actual_sales_price)) ? (float) $actual_sales_price : (float) $actual_regular_price;
+            }
         }
 
-        $product_price = (isset($actual_sales_price) && !empty($actual_sales_price)) ? $actual_sales_price : $actual_regular_price;
+        /**
+         * Allow the price the offer is measured against for the auto
+         * accept/decline decision to be overridden.
+         *
+         * @param float $product_price Price used to calculate the offer percentage.
+         * @param int   $product_id    Product ID.
+         * @param int   $variant_id    Variation ID (0 when none).
+         * @param int   $offer_id      Offer post ID.
+         */
+        $product_price = (float) apply_filters('aeofw_auto_decision_product_price', $product_price, $product_id, $variant_id, $offer_id);
+
         $productData['offer_price'] = $offer_price = get_post_meta($offer_id, 'offer_price_per', true);
         $productData['user_offer_percentage'] = 0;
         if ($product_price > 0) {
             $productData['user_offer_percentage'] = $this->ofwc_get_percentage($offer_price, $product_price);
         }
-        $product = ( $variant_id ) ? wc_get_product($variant_id) : wc_get_product($product_id);
-        $productData['product_url'] = $product->get_permalink();
+        $productData['product_url'] = $product ? $product->get_permalink() : '';
         $productData['offer_uid'] = get_post_meta($offer_id, 'offer_uid', true);
 
         return $productData;


### PR DESCRIPTION
## Summary

The auto accept/decline decision was based on the original product price stored in the product settings, ignoring price modifications applied through the `woocommerce_product_get_price` filter. On stores using dynamic pricing this evaluated offers against the wrong base price.

`Angelleye_Offers_For_Woocommerce::ofwc_get_product_detail()` read `_regular_price` / `_sale_price` directly from post meta, which bypasses that filter. It now uses `$product->get_price()` (the filtered/live price), so dynamic pricing plugins such as **GVM Price Decay Tool** and **GVM Category Discounts** are respected. Both use the same filter, so one change covers both.

## Details

- Decision price now comes from `$product->get_price()`, which runs `woocommerce_product_get_price` (and `woocommerce_product_variation_get_price` for variations).
- Falls back to the stored `_regular_price` / `_sale_price` when the live price is unavailable (e.g. price-on-request), preserving previous behavior in that case.
- Adds an `aeofw_auto_decision_product_price` filter to override the price used for the decision.
- The accepted final offer price still gets the last word at checkout (existing behavior, unchanged).

## Testing

Verified on a live install with a `woocommerce_product_get_price` filter decaying a $3 product to $2, product set to auto accept at 90% of price:
- Offer $1.90 → read as **95%** of the live $2 price → accepted (previously 63% of the original $3 → left pending).
- Offer $1.50 → 75% → left pending.

`php -l` clean.